### PR TITLE
Fix launch issues and document helper scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,5 +218,19 @@ npm run dev
 
 The frontend expects `NEXT_PUBLIC_API_BASE` (default `http://localhost:8000/api/v1`) and the backend reads `.env` values for secrets and CORS configuration. Replace the in-memory seed data with your production database of choice as the next milestone.
 
+### Launch helper scripts
+
+For convenience the repository provides wrapper scripts that set up dependencies and start both services together:
+
+```bash
+# macOS/Linux
+./launch.sh
+
+# Windows (PowerShell)
+pwsh -File launch.ps1
+```
+
+Both scripts automatically create the backend virtual environment, install/update dependencies, load environment variables from any available `.env` files, and then run the FastAPI and Next.js development servers. When you are finished, press <kbd>Ctrl</kbd>+<kbd>C</kbd> in the same terminal and the scripts will shut down both processes cleanly.
+
 ## Testing
 ⚠️ Tests not run (planning document only).

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,6 +3,7 @@ uvicorn[standard]==0.29.0
 pydantic==1.10.15
 python-multipart==0.0.9
 passlib[bcrypt]==1.7.4
+bcrypt==4.0.1
 PyJWT==2.8.0
 httpx==0.27.0
 pytest==8.2.0

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -1,9 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  reactStrictMode: true,
-  experimental: {
-    serverActions: false
-  }
+  reactStrictMode: true
 };
 
 export default nextConfig;

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -14,8 +14,9 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
-    "types": ["node"]
+    "types": ["node"],
+    "plugins": [{ "name": "next" }]
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Summary
- pin the bcrypt dependency so the backend no longer crashes when passlib loads
- remove the obsolete serverActions flag and sync the Next.js TypeScript settings with the framework defaults
- document how to launch and stop both services via the helper scripts

## Testing
- not run (not run)

------
https://chatgpt.com/codex/tasks/task_e_68d2e480186c8333a22f3aa4627aee65