### PR TITLE
Add client dashboard aggregating project and financial data

### DIFF
--- a/backend/app/api/routes/__init__.py
+++ b/backend/app/api/routes/__init__.py
@@ -1,4 +1,15 @@
-from . import auth, clients, dashboard, financials, hr, marketing, monitoring, projects, support  # noqa: F401
+from . import (
+    auth,
+    clients,
+    dashboard,
+    financials,
+    hr,
+    marketing,
+    monitoring,
+    project_templates,
+    projects,
+    support,
+)  # noqa: F401
 
 __all__ = [
     "auth",
@@ -8,6 +19,7 @@ __all__ = [
     "hr",
     "marketing",
     "monitoring",
+    "project_templates",
     "projects",
     "support",
 ]

--- a/backend/app/api/routes/clients.py
+++ b/backend/app/api/routes/clients.py
@@ -1,8 +1,14 @@
 from typing import List
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, status
 
-from ...schemas.clients import Client, ClientSummary
+from ...schemas.clients import (
+    Client,
+    ClientCreateRequest,
+    ClientDashboard,
+    ClientSummary,
+    ClientWithProjects,
+)
 from ...services.data import store
 
 router = APIRouter(prefix="/clients", tags=["clients"])
@@ -24,3 +30,19 @@ def get_client(client_id: str) -> Client:
 @router.get("/summary", response_model=ClientSummary)
 def client_summary() -> ClientSummary:
     return store.client_summary()
+
+
+@router.post("", response_model=ClientWithProjects, status_code=status.HTTP_201_CREATED)
+def create_client(payload: ClientCreateRequest) -> ClientWithProjects:
+    try:
+        return store.create_client_with_projects(payload)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@router.get("/{client_id}/dashboard", response_model=ClientDashboard)
+def client_dashboard(client_id: str) -> ClientDashboard:
+    try:
+        return store.client_dashboard(client_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc

--- a/backend/app/api/routes/project_templates.py
+++ b/backend/app/api/routes/project_templates.py
@@ -1,0 +1,43 @@
+from fastapi import APIRouter, HTTPException, status
+
+from ...schemas.project_templates import (
+    ProjectTemplateCreateRequest,
+    ProjectTemplateCreateResponse,
+)
+from ...services.project_templates import (
+    MilestoneBlueprint,
+    ProjectTemplate,
+    TaskBlueprint,
+    register_template,
+)
+
+router = APIRouter(prefix="/project-templates", tags=["project_templates"])
+
+
+@router.post("", response_model=ProjectTemplateCreateResponse, status_code=status.HTTP_201_CREATED)
+def create_project_template(payload: ProjectTemplateCreateRequest) -> ProjectTemplateCreateResponse:
+    template = ProjectTemplate(
+        code_prefix=payload.code_prefix,
+        tasks=[
+            TaskBlueprint(
+                name=task.name,
+                duration_days=task.duration_days,
+                depends_on=task.depends_on,
+                status=task.status,
+                estimated_hours=task.estimated_hours,
+                billable=task.billable,
+            )
+            for task in payload.tasks
+        ],
+        milestones=[
+            MilestoneBlueprint(title=milestone.title, offset_days=milestone.offset_days)
+            for milestone in payload.milestones
+        ],
+    )
+
+    try:
+        register_template(payload.template_id, template, overwrite=payload.overwrite)
+    except ValueError as exc:  # pragma: no cover - defensive
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    return ProjectTemplateCreateResponse(template_id=payload.template_id)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,7 +2,18 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from .core.config import get_settings
-from .api.routes import auth, clients, dashboard, financials, hr, marketing, monitoring, projects, support
+from .api.routes import (
+    auth,
+    clients,
+    dashboard,
+    financials,
+    hr,
+    marketing,
+    monitoring,
+    project_templates,
+    projects,
+    support,
+)
 
 settings = get_settings()
 
@@ -19,6 +30,7 @@ app.add_middleware(
 app.include_router(auth.router, prefix=settings.api_v1_str)
 app.include_router(dashboard.router, prefix=settings.api_v1_str)
 app.include_router(projects.router, prefix=settings.api_v1_str)
+app.include_router(project_templates.router, prefix=settings.api_v1_str)
 app.include_router(clients.router, prefix=settings.api_v1_str)
 app.include_router(financials.router, prefix=settings.api_v1_str)
 app.include_router(support.router, prefix=settings.api_v1_str)

--- a/backend/app/schemas/clients.py
+++ b/backend/app/schemas/clients.py
@@ -5,6 +5,11 @@ from datetime import datetime
 from pydantic import BaseModel, EmailStr, Field
 
 from .common import IdentifiedModel
+from pydantic.class_validators import root_validator
+
+from .projects import Milestone, Project, ProjectStatus, Task
+from .financials import Currency, InvoiceStatus
+from .support import TicketStatus
 
 
 class Industry(str, Enum):
@@ -68,3 +73,109 @@ class ClientSummary(BaseModel):
     total_clients: int
     by_segment: dict
     active_portal_users: int
+
+
+class ProjectSetup(BaseModel):
+    name: str
+    template_id: str = Field(..., alias="project_type")
+    start_date: datetime
+    manager_id: str
+    budget: float
+    currency: str = "USD"
+    start_after_name: Optional[str] = Field(default=None, alias="start_after")
+
+    class Config:
+        allow_population_by_field_name = True
+
+
+class ClientCreateRequest(BaseModel):
+    organization_name: str
+    industry: Industry
+    segment: ClientSegment
+    billing_email: EmailStr
+    preferred_channel: InteractionChannel = InteractionChannel.EMAIL
+    timezone: str = "UTC"
+    contacts: List[Contact] = Field(default_factory=list)
+    projects: List[ProjectSetup] = Field(default_factory=list)
+
+    @root_validator(pre=True)
+    def coerce_project_list(cls, values: dict) -> dict:
+        single_project = values.pop("project", None)
+        projects = values.get("projects")
+        if single_project and projects:
+            raise ValueError("Provide either 'project' or 'projects', not both")
+        if single_project and not projects:
+            values["projects"] = [single_project]
+        if not values.get("projects"):
+            raise ValueError("At least one project setup is required")
+        return values
+
+
+class ClientWithProjects(BaseModel):
+    client: Client
+    projects: List[Project]
+
+
+class ClientProjectDigest(BaseModel):
+    id: str
+    code: str
+    name: str
+    project_type: str
+    status: ProjectStatus
+    start_date: datetime
+    end_date: Optional[datetime] = None
+    manager_id: str
+    budget: Optional[float] = None
+    currency: str = "USD"
+    late_tasks: List[Task] = Field(default_factory=list)
+    next_task: Optional[Task] = None
+    next_milestone: Optional[Milestone] = None
+
+
+class ClientInvoiceDigest(BaseModel):
+    id: str
+    number: str
+    status: InvoiceStatus
+    due_date: datetime
+    total: float
+    balance_due: float
+    currency: Currency
+    project_id: Optional[str] = None
+    project_name: Optional[str] = None
+
+
+class ClientPaymentDigest(BaseModel):
+    id: str
+    invoice_id: str
+    invoice_number: Optional[str]
+    amount: float
+    received_at: datetime
+    method: str
+
+
+class ClientFinancialSnapshot(BaseModel):
+    outstanding_invoices: List[ClientInvoiceDigest] = Field(default_factory=list)
+    next_invoice_due: Optional[ClientInvoiceDigest] = None
+    recent_payments: List[ClientPaymentDigest] = Field(default_factory=list)
+    total_outstanding: float = 0.0
+
+
+class ClientTicketDigest(BaseModel):
+    id: str
+    subject: str
+    status: TicketStatus
+    priority: str
+    sla_due: Optional[datetime] = None
+    last_activity_at: Optional[datetime] = None
+
+
+class ClientSupportSnapshot(BaseModel):
+    open_tickets: List[ClientTicketDigest] = Field(default_factory=list)
+    last_ticket_update: Optional[datetime] = None
+
+
+class ClientDashboard(BaseModel):
+    client: Client
+    projects: List[ClientProjectDigest] = Field(default_factory=list)
+    financials: ClientFinancialSnapshot
+    support: ClientSupportSnapshot

--- a/backend/app/schemas/project_templates.py
+++ b/backend/app/schemas/project_templates.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from typing import List, Optional
+
+from pydantic import BaseModel, Field, root_validator
+
+from .projects import TaskStatus
+
+
+class ProjectTemplateTaskDefinition(BaseModel):
+    name: str
+    duration_days: int = Field(..., gt=0)
+    depends_on: List[str] = Field(default_factory=list)
+    status: TaskStatus = TaskStatus.TODO
+    estimated_hours: Optional[float] = None
+    billable: bool = True
+
+
+class ProjectTemplateMilestoneDefinition(BaseModel):
+    title: str
+    offset_days: int = Field(..., ge=0)
+
+
+class ProjectTemplateCreateRequest(BaseModel):
+    template_id: str = Field(..., min_length=2)
+    code_prefix: str = Field(..., min_length=2, max_length=12)
+    tasks: List[ProjectTemplateTaskDefinition]
+    milestones: List[ProjectTemplateMilestoneDefinition] = Field(default_factory=list)
+    overwrite: bool = False
+
+    @root_validator
+    def validate_dependencies(cls, values: dict) -> dict:
+        tasks = values.get("tasks") or []
+        task_names = {task.name for task in tasks}
+        if len(task_names) != len(tasks):
+            raise ValueError("Task names within a template must be unique")
+        for task in tasks:
+            missing = set(task.depends_on) - task_names
+            if missing:
+                missing_str = ", ".join(sorted(missing))
+                raise ValueError(
+                    f"Task '{task.name}' references unknown dependencies: {missing_str}"
+                )
+        return values
+
+
+class ProjectTemplateCreateResponse(BaseModel):
+    template_id: str

--- a/backend/app/schemas/projects.py
+++ b/backend/app/schemas/projects.py
@@ -22,6 +22,12 @@ class TaskStatus(str, Enum):
     DONE = "done"
 
 
+class ProjectTemplateType(str, Enum):
+    WEBSITE = "website"
+    BRANDING = "branding"
+    CONSULTING = "consulting"
+
+
 class Task(IdentifiedModel):
     name: str
     status: TaskStatus = TaskStatus.TODO
@@ -30,6 +36,7 @@ class Task(IdentifiedModel):
     billable: bool = True
     estimated_hours: Optional[float] = None
     logged_hours: float = 0
+    dependencies: List[str] = Field(default_factory=list)
 
 
 class Milestone(IdentifiedModel):

--- a/backend/app/services/project_templates.py
+++ b/backend/app/services/project_templates.py
@@ -1,0 +1,254 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import Dict, Iterable, List, Optional
+
+from ..schemas.projects import Milestone, Task, TaskStatus
+
+
+@dataclass(frozen=True)
+class TaskBlueprint:
+    name: str
+    duration_days: int
+    depends_on: Iterable[str] = ()
+    status: TaskStatus = TaskStatus.TODO
+    estimated_hours: Optional[float] = None
+    billable: bool = True
+
+
+@dataclass(frozen=True)
+class MilestoneBlueprint:
+    title: str
+    offset_days: int
+
+
+class ProjectTemplate:
+    def __init__(
+        self,
+        *,
+        code_prefix: str,
+        tasks: Iterable[TaskBlueprint],
+        milestones: Iterable[MilestoneBlueprint] = (),
+    ) -> None:
+        self.code_prefix = code_prefix
+        self.tasks = list(tasks)
+        self.milestones = list(milestones)
+
+
+class ProjectTemplateLibrary:
+    def __init__(self, templates: Optional[Dict[str, ProjectTemplate]] = None) -> None:
+        self._templates: Dict[str, ProjectTemplate] = {}
+        if templates:
+            for template_id, template in templates.items():
+                self.register(template_id, template, overwrite=True)
+
+    def register(self, template_id: str, template: ProjectTemplate, *, overwrite: bool = False) -> None:
+        if not template.tasks:
+            raise ValueError("Project template must include at least one task")
+        if not overwrite and template_id in self._templates:
+            raise ValueError(f"Project template '{template_id}' already exists")
+        self._validate_template(template)
+        self._templates[template_id] = template
+
+    def unregister(self, template_id: str) -> None:
+        self._templates.pop(template_id, None)
+
+    def exists(self, template_id: str) -> bool:
+        return template_id in self._templates
+
+    def code_prefix(self, template_id: str) -> str:
+        template = self._templates.get(template_id)
+        if not template:
+            raise ValueError(f"Unknown project template: {template_id}")
+        return template.code_prefix
+
+    def build_plan(self, template_id: str, start_date: datetime) -> tuple[List[Task], List[Milestone]]:
+        template = self._templates.get(template_id)
+        if not template:
+            raise ValueError(f"Unknown project template: {template_id}")
+        tasks: List[Task] = []
+        dependencies_lookup: Dict[str, List[str]] = {}
+        completion_lookup: Dict[str, datetime] = {}
+
+        for blueprint in template.tasks:
+            dependency_completion = [completion_lookup[name] for name in blueprint.depends_on]
+            start_anchor = max(dependency_completion) if dependency_completion else start_date
+            due_date = start_anchor + timedelta(days=blueprint.duration_days)
+            task = Task(
+                name=blueprint.name,
+                status=blueprint.status,
+                estimated_hours=blueprint.estimated_hours,
+                billable=blueprint.billable,
+                due_date=due_date,
+            )
+            tasks.append(task)
+            dependencies_lookup[task.id] = list(blueprint.depends_on)
+            completion_lookup[blueprint.name] = due_date
+
+        name_to_id = {task.name: task.id for task in tasks}
+        for task in tasks:
+            dependency_names = dependencies_lookup[task.id]
+            task.dependencies = [name_to_id[name] for name in dependency_names if name in name_to_id]
+
+        milestones = [
+            Milestone(title=milestone.title, due_date=start_date + timedelta(days=milestone.offset_days))
+            for milestone in template.milestones
+        ]
+        return tasks, milestones
+
+    def _validate_template(self, template: ProjectTemplate) -> None:
+        task_names = {blueprint.name for blueprint in template.tasks}
+        for blueprint in template.tasks:
+            if blueprint.duration_days <= 0:
+                raise ValueError(f"Task '{blueprint.name}' must have a positive duration")
+            missing = set(blueprint.depends_on) - task_names
+            if missing:
+                missing_str = ", ".join(sorted(missing))
+                raise ValueError(
+                    f"Task '{blueprint.name}' references unknown dependencies: {missing_str}"
+                )
+
+
+DEFAULT_TEMPLATES: Dict[str, ProjectTemplate] = {
+    "website": ProjectTemplate(
+        code_prefix="WEB",
+        tasks=[
+            TaskBlueprint(name="Project Kickoff", duration_days=2, estimated_hours=6),
+            TaskBlueprint(
+                name="Discovery & Strategy",
+                duration_days=5,
+                depends_on=["Project Kickoff"],
+                estimated_hours=16,
+            ),
+            TaskBlueprint(
+                name="Content Architecture",
+                duration_days=4,
+                depends_on=["Discovery & Strategy"],
+                estimated_hours=12,
+            ),
+            TaskBlueprint(
+                name="Visual Design",
+                duration_days=7,
+                depends_on=["Content Architecture"],
+                estimated_hours=30,
+            ),
+            TaskBlueprint(
+                name="Development Sprint",
+                duration_days=10,
+                depends_on=["Visual Design"],
+                estimated_hours=45,
+            ),
+            TaskBlueprint(
+                name="Quality Assurance",
+                duration_days=4,
+                depends_on=["Development Sprint"],
+                estimated_hours=18,
+            ),
+            TaskBlueprint(
+                name="Launch",
+                duration_days=1,
+                depends_on=["Quality Assurance"],
+                estimated_hours=4,
+            ),
+        ],
+        milestones=[
+            MilestoneBlueprint(title="Design Approved", offset_days=14),
+            MilestoneBlueprint(title="Website Launched", offset_days=33),
+        ],
+    ),
+    "branding": ProjectTemplate(
+        code_prefix="BRD",
+        tasks=[
+            TaskBlueprint(name="Brand Workshop", duration_days=3, estimated_hours=8),
+            TaskBlueprint(
+                name="Audience Research",
+                duration_days=6,
+                depends_on=["Brand Workshop"],
+                estimated_hours=20,
+            ),
+            TaskBlueprint(
+                name="Moodboards",
+                duration_days=4,
+                depends_on=["Audience Research"],
+                estimated_hours=16,
+            ),
+            TaskBlueprint(
+                name="Logo Exploration",
+                duration_days=5,
+                depends_on=["Moodboards"],
+                estimated_hours=24,
+            ),
+            TaskBlueprint(
+                name="Brand Guidelines",
+                duration_days=7,
+                depends_on=["Logo Exploration"],
+                estimated_hours=28,
+            ),
+            TaskBlueprint(
+                name="Handover",
+                duration_days=2,
+                depends_on=["Brand Guidelines"],
+                estimated_hours=6,
+            ),
+        ],
+        milestones=[
+            MilestoneBlueprint(title="Concept Approved", offset_days=12),
+            MilestoneBlueprint(title="Guidelines Delivered", offset_days=27),
+        ],
+    ),
+    "consulting": ProjectTemplate(
+        code_prefix="CON",
+        tasks=[
+            TaskBlueprint(name="Initial Assessment", duration_days=3, estimated_hours=10),
+            TaskBlueprint(
+                name="Stakeholder Interviews",
+                duration_days=5,
+                depends_on=["Initial Assessment"],
+                estimated_hours=18,
+            ),
+            TaskBlueprint(
+                name="Findings Synthesis",
+                duration_days=4,
+                depends_on=["Stakeholder Interviews"],
+                estimated_hours=14,
+            ),
+            TaskBlueprint(
+                name="Opportunity Mapping",
+                duration_days=4,
+                depends_on=["Findings Synthesis"],
+                estimated_hours=12,
+            ),
+            TaskBlueprint(
+                name="Roadmap Presentation",
+                duration_days=2,
+                depends_on=["Opportunity Mapping"],
+                estimated_hours=10,
+            ),
+        ],
+        milestones=[
+            MilestoneBlueprint(title="Discovery Complete", offset_days=10),
+            MilestoneBlueprint(title="Final Presentation", offset_days=18),
+        ],
+    ),
+}
+
+
+template_library = ProjectTemplateLibrary(DEFAULT_TEMPLATES)
+
+
+def register_template(template_id: str, template: ProjectTemplate, *, overwrite: bool = False) -> None:
+    template_library.register(template_id, template, overwrite=overwrite)
+
+
+def unregister_template(template_id: str) -> None:
+    template_library.unregister(template_id)
+
+
+def build_plan(template_id: str, start_date: datetime) -> tuple[List[Task], List[Milestone]]:
+    return template_library.build_plan(template_id, start_date)
+
+
+def project_code(prefix: str, sequence: int, *, year: int | None = None) -> str:
+    year = year or datetime.utcnow().year
+    return f"{prefix}-{year}-{sequence:02d}"

--- a/backend/tests/test_clients.py
+++ b/backend/tests/test_clients.py
@@ -1,0 +1,265 @@
+from __future__ import annotations
+
+import inspect
+from datetime import datetime
+from pathlib import Path
+import sys
+from typing import ForwardRef, Iterable
+
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+
+_forward_ref_signature = inspect.signature(ForwardRef._evaluate)
+if "recursive_guard" in _forward_ref_signature.parameters:
+    _original_forward_ref_evaluate = ForwardRef._evaluate
+
+    def _patched_forward_ref_evaluate(self, globalns, localns, *args, **kwargs):
+        if "recursive_guard" not in kwargs and args:
+            kwargs["recursive_guard"] = args[-1]
+            args = args[:-1]
+        return _original_forward_ref_evaluate(self, globalns, localns, *args, **kwargs)
+
+    ForwardRef._evaluate = _patched_forward_ref_evaluate
+
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from app.main import app  # noqa: E402
+from app.services.data import store  # noqa: E402
+from app.services.project_templates import template_library, unregister_template  # noqa: E402
+from app.schemas.projects import ProjectTemplateType  # noqa: E402
+from app.schemas.clients import Client  # noqa: E402
+
+
+client = TestClient(app)
+
+
+def _cleanup(client_id: str, project_ids: Iterable[str]) -> None:
+    store.clients.pop(client_id, None)
+    for project_id in project_ids:
+        store.projects.pop(project_id, None)
+
+
+def _seeded_client_with_data() -> Client:
+    for client in store.clients.values():
+        if client.organization_name == "Sunset Boutique Hotel":
+            return client
+    raise AssertionError("Expected seeded client not found")
+
+
+def test_create_client_with_single_project_template() -> None:
+    start = datetime.utcnow().replace(microsecond=0)
+    payload = {
+        "organization_name": "Northwind Ventures",
+        "industry": "technology",
+        "segment": "project",
+        "billing_email": "finance@northwind.example",
+        "preferred_channel": "email",
+        "timezone": "UTC",
+        "contacts": [
+            {
+                "first_name": "Lena",
+                "last_name": "Park",
+                "email": "lena@northwind.example",
+                "title": "COO",
+            }
+        ],
+        "projects": [
+            {
+                "name": "Brand Refresh Initiative",
+                "project_type": ProjectTemplateType.BRANDING.value,
+                "start_date": start.isoformat(),
+                "manager_id": "pm-42",
+                "budget": 26000,
+                "currency": "USD",
+            }
+        ],
+    }
+
+    response = client.post("/api/v1/clients", json=payload)
+    assert response.status_code == 201
+
+    body = response.json()
+    created_client = body["client"]
+    created_projects = body["projects"]
+
+    assert len(created_projects) == 1
+    created_project = created_projects[0]
+
+    try:
+        assert created_client["organization_name"] == payload["organization_name"]
+        assert created_project["project_type"] == payload["projects"][0]["project_type"]
+
+        expected_task_count = len(template_library.build_plan(ProjectTemplateType.BRANDING.value, start)[0])
+        assert len(created_project["tasks"]) == expected_task_count
+
+        task_ids = {task["id"] for task in created_project["tasks"]}
+        assert task_ids  # ensure tasks exist
+
+        for task in created_project["tasks"]:
+            assert set(task.get("dependencies", [])) <= task_ids
+            due = datetime.fromisoformat(task["due_date"])
+            assert due >= start
+
+        for milestone in created_project["milestones"]:
+            milestone_due = datetime.fromisoformat(milestone["due_date"])
+            assert milestone_due >= start
+
+        assert any(task["dependencies"] for task in created_project["tasks"][1:])
+    finally:
+        _cleanup(created_client["id"], [created_project["id"]])
+
+
+def test_branding_then_website_sequence() -> None:
+    start = datetime.utcnow().replace(microsecond=0)
+    payload = {
+        "organization_name": "Blue Skyline Retail",
+        "industry": "creative",
+        "segment": "project",
+        "billing_email": "ops@blueskyline.example",
+        "preferred_channel": "email",
+        "timezone": "UTC",
+        "projects": [
+            {
+                "name": "Blue Skyline Brand System",
+                "project_type": ProjectTemplateType.BRANDING.value,
+                "start_date": start.isoformat(),
+                "manager_id": "pm-12",
+                "budget": 32000,
+                "currency": "USD",
+            },
+            {
+                "name": "Blue Skyline Website",
+                "project_type": ProjectTemplateType.WEBSITE.value,
+                "start_date": start.isoformat(),
+                "manager_id": "pm-34",
+                "budget": 45000,
+                "currency": "USD",
+            },
+        ],
+    }
+
+    response = client.post("/api/v1/clients", json=payload)
+    assert response.status_code == 201
+
+    body = response.json()
+    created_client = body["client"]
+    created_projects = body["projects"]
+    assert len(created_projects) == 2
+
+    try:
+        branding_project = next(
+            project for project in created_projects if project["project_type"] == ProjectTemplateType.BRANDING.value
+        )
+        website_project = next(
+            project for project in created_projects if project["project_type"] == ProjectTemplateType.WEBSITE.value
+        )
+
+        branding_end = datetime.fromisoformat(branding_project["end_date"])
+        website_start = datetime.fromisoformat(website_project["start_date"])
+        assert website_start >= branding_end
+
+        earliest_website_due = min(
+            datetime.fromisoformat(task["due_date"]) for task in website_project["tasks"]
+        )
+        assert earliest_website_due >= branding_end
+    finally:
+        _cleanup(created_client["id"], [project["id"] for project in created_projects])
+
+
+def test_create_and_use_custom_project_template() -> None:
+    template_payload = {
+        "template_id": "ops-advisory",
+        "code_prefix": "OPS",
+        "tasks": [
+            {"name": "Kickoff Session", "duration_days": 2},
+            {
+                "name": "Opportunity Deep Dive",
+                "duration_days": 4,
+                "depends_on": ["Kickoff Session"],
+                "estimated_hours": 18,
+            },
+        ],
+        "milestones": [
+            {"title": "Alignment Workshop", "offset_days": 3},
+        ],
+    }
+
+    template_response = client.post("/api/v1/project-templates", json=template_payload)
+    assert template_response.status_code == 201
+
+    start = datetime.utcnow().replace(microsecond=0)
+    client_payload = {
+        "organization_name": "Orchid Advisory",
+        "industry": "technology",
+        "segment": "project",
+        "billing_email": "finance@orchid.example",
+        "projects": [
+            {
+                "name": "Operational Advisory",
+                "project_type": template_payload["template_id"],
+                "start_date": start.isoformat(),
+                "manager_id": "pm-88",
+                "budget": 18000,
+                "currency": "USD",
+            }
+        ],
+    }
+
+    response = client.post("/api/v1/clients", json=client_payload)
+    assert response.status_code == 201
+    body = response.json()
+    created_client = body["client"]
+    created_project = body["projects"][0]
+
+    try:
+        assert created_project["project_type"] == template_payload["template_id"]
+        assert created_project["code"].startswith(template_payload["code_prefix"])
+        assert len(created_project["tasks"]) == len(template_payload["tasks"])
+
+        second_task = created_project["tasks"][1]
+        assert second_task["dependencies"]
+    finally:
+        _cleanup(created_client["id"], [created_project["id"]])
+        unregister_template(template_payload["template_id"])
+
+
+def test_client_dashboard_links_related_entities() -> None:
+    seeded_client = _seeded_client_with_data()
+
+    response = client.get(f"/api/v1/clients/{seeded_client.id}/dashboard")
+    assert response.status_code == 200
+
+    body = response.json()
+    assert body["client"]["id"] == seeded_client.id
+
+    projects = body["projects"]
+    assert projects
+
+    project_digest = next(
+        project for project in projects if project["name"] == "Sunset Boutique Website Refresh"
+    )
+    assert project_digest["code"]
+    assert project_digest["status"] in {"in_progress", "planning", "completed", "on_hold", "cancelled"}
+    assert "late_tasks" in project_digest
+    assert project_digest["next_milestone"]["title"] == "Launch MVP"
+    if project_digest["next_task"]:
+        assert project_digest["next_task"]["status"] != "done"
+
+    financials = body["financials"]
+    assert financials["total_outstanding"] >= 0
+    assert financials["outstanding_invoices"]
+    assert financials["next_invoice_due"]["balance_due"] > 0
+    assert financials["recent_payments"]
+
+    support = body["support"]
+    assert support["open_tickets"]
+    ticket = support["open_tickets"][0]
+    assert ticket["status"] in {"open", "in_progress"}
+    assert support["last_ticket_update"] is not None
+
+
+def test_client_dashboard_missing_client_returns_404() -> None:
+    response = client.get("/api/v1/clients/non-existent/dashboard")
+    assert response.status_code == 404


### PR DESCRIPTION
## Summary
- add a client dashboard endpoint that aggregates project, financial, and support insights for a single client
- extend client schemas with digest models that link projects, invoices, payments, and support tickets
- implement the in-memory store dashboard computation and cover it with integration tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d2eb74ed408333865a64c02e24266f