### PR TITLE
Add automated PH tax calculator and pricing insights

### DIFF
--- a/backend/app/api/routes/financials.py
+++ b/backend/app/api/routes/financials.py
@@ -2,7 +2,17 @@ from typing import List
 
 from fastapi import APIRouter, HTTPException
 
-from ...schemas.financials import Expense, FinancialSummary, Invoice, Payment
+from ...schemas.financials import (
+    Expense,
+    FinancialSummary,
+    Invoice,
+    MacroFinancials,
+    Payment,
+    PricingSuggestion,
+    ProjectFinancials,
+    TaxComputationRequest,
+    TaxComputationResponse,
+)
 from ...services.data import store
 
 router = APIRouter(prefix="/financials", tags=["financials"])
@@ -34,3 +44,23 @@ def list_expenses() -> List[Expense]:
 @router.get("/summary", response_model=FinancialSummary)
 def financial_summary() -> FinancialSummary:
     return store.financial_summary()
+
+
+@router.get("/projects", response_model=List[ProjectFinancials])
+def project_financials() -> List[ProjectFinancials]:
+    return store.project_financials()
+
+
+@router.get("/overview", response_model=MacroFinancials)
+def macro_financials() -> MacroFinancials:
+    return store.macro_financials()
+
+
+@router.post("/tax/compute", response_model=TaxComputationResponse)
+def compute_tax(payload: TaxComputationRequest) -> TaxComputationResponse:
+    return store.calculate_tax(payload)
+
+
+@router.get("/pricing/suggestions", response_model=List[PricingSuggestion])
+def pricing_suggestions() -> List[PricingSuggestion]:
+    return store.pricing_suggestions()

--- a/backend/app/schemas/financials.py
+++ b/backend/app/schemas/financials.py
@@ -61,3 +61,68 @@ class FinancialSummary(BaseModel):
     outstanding_invoices: float
     overdue_invoices: int
     expenses_this_month: float
+
+
+class ProjectFinancials(BaseModel):
+    project_id: str
+    project_name: str
+    client_name: Optional[str]
+    currency: Currency = Currency.USD
+    total_invoiced: float
+    total_collected: float
+    total_expenses: float
+    outstanding_amount: float
+    net_revenue: float
+
+
+class MacroFinancials(BaseModel):
+    total_invoiced: float
+    total_collected: float
+    total_outstanding: float
+    total_expenses: float
+    net_cash_flow: float
+
+
+class TaxEntry(BaseModel):
+    label: str
+    amount: float
+
+
+class TaxComputationRequest(BaseModel):
+    incomes: List[TaxEntry] = Field(default_factory=list)
+    cost_of_sales: List[TaxEntry] = Field(default_factory=list)
+    operating_expenses: List[TaxEntry] = Field(default_factory=list)
+    other_deductions: List[TaxEntry] = Field(default_factory=list)
+    apply_percentage_tax: bool = True
+    percentage_tax_rate: float = 3.0
+    vat_registered: bool = False
+
+
+class DeductionOpportunity(BaseModel):
+    category: str
+    message: str
+
+
+class TaxComputationResponse(BaseModel):
+    gross_revenue: float
+    total_cost_of_sales: float
+    total_operating_expenses: float
+    total_other_deductions: float
+    taxable_income: float
+    income_tax: float
+    percentage_tax: float
+    vat_due: float
+    total_tax: float
+    effective_tax_rate: float
+    deduction_opportunities: List[DeductionOpportunity] = Field(default_factory=list)
+
+
+class PricingSuggestion(BaseModel):
+    project_id: str
+    service: str
+    current_rate: float
+    recommended_rate: float
+    current_margin: float
+    recommended_adjustment_pct: float
+    rationale: str
+    currency: Currency = Currency.USD

--- a/backend/tests/test_financials.py
+++ b/backend/tests/test_financials.py
@@ -1,0 +1,79 @@
+from datetime import datetime
+
+import pytest
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.schemas.financials import Expense, Invoice, InvoiceStatus, LineItem, Payment, TaxComputationRequest
+from app.services.data import store
+
+
+client = TestClient(app)
+
+
+def test_tax_computation_endpoint_returns_expected_totals() -> None:
+    payload = TaxComputationRequest(
+        incomes=[{"label": "Design retainers", "amount": 1_500_000}],
+        cost_of_sales=[{"label": "Subcontractors", "amount": 400_000}],
+        operating_expenses=[{"label": "Rent", "amount": 200_000}],
+        other_deductions=[{"label": "PhilHealth", "amount": 30_000}],
+        apply_percentage_tax=True,
+        percentage_tax_rate=3,
+        vat_registered=False,
+    )
+
+    response = client.post("/api/v1/financials/tax/compute", json=payload.dict())
+    assert response.status_code == 200
+    data = response.json()
+
+    assert data["gross_revenue"] == 1_500_000
+    assert data["total_cost_of_sales"] == 400_000
+    assert data["total_operating_expenses"] == 200_000
+    assert data["total_other_deductions"] == 30_000
+    assert data["taxable_income"] == 870_000
+    # 870k falls in the 800k-2M bracket: 130k base + 70k * 30%
+    assert data["income_tax"] == 151_000
+    assert data["percentage_tax"] == 45_000
+    assert data["vat_due"] == 0
+    assert data["total_tax"] == 196_000
+    assert data["effective_tax_rate"] == pytest.approx(13.06, rel=1e-2)
+    # Expect deduction guidance for categories not supplied in request
+    categories = {tip["category"] for tip in data["deduction_opportunities"]}
+    assert "sss" in categories
+    assert "pag-ibig" in categories
+
+
+def test_pricing_suggestions_flag_low_margin_projects() -> None:
+    project = next(iter(store.projects.values()))
+    now = datetime.utcnow()
+    invoice = Invoice(
+        client_id=project.client_id,
+        project_id=project.id,
+        number="INV-LOW-MARGIN",
+        status=InvoiceStatus.PAID,
+        issue_date=now,
+        due_date=now,
+        items=[LineItem(description="Support bundle", quantity=1, unit_price=1_000, total=1_000)],
+    )
+    payment = Payment(invoice_id=invoice.id, amount=1_000, received_at=now, method="bank_transfer")
+    expense = Expense(project_id=project.id, category="Subcontractor", amount=4_800, incurred_at=now)
+
+    store.invoices[invoice.id] = invoice
+    store.payments[payment.id] = payment
+    store.expenses[expense.id] = expense
+
+    try:
+        response = client.get("/api/v1/financials/pricing/suggestions")
+        assert response.status_code == 200
+        suggestions = response.json()
+        assert suggestions
+
+        matching = next(s for s in suggestions if s["project_id"] == project.id)
+        assert matching["recommended_rate"] >= matching["current_rate"]
+        assert matching["recommended_adjustment_pct"] >= 0
+        assert "Recommend increasing" in matching["rationale"] or "below" in matching["rationale"].lower()
+    finally:
+        store.invoices.pop(invoice.id, None)
+        store.payments.pop(payment.id, None)
+        store.expenses.pop(expense.id, None)

--- a/frontend/app/components/Sidebar.tsx
+++ b/frontend/app/components/Sidebar.tsx
@@ -9,6 +9,7 @@ const navItems = [
   { href: "/projects", label: "Projects" },
   { href: "/clients", label: "Clients" },
   { href: "/financials", label: "Financials" },
+  { href: "/financials/tax-calculator", label: "Tax tools" },
   { href: "/support", label: "Support" },
   { href: "/hr", label: "People" },
   { href: "/marketing", label: "Marketing" },

--- a/frontend/app/financials/page.tsx
+++ b/frontend/app/financials/page.tsx
@@ -1,9 +1,24 @@
 export const dynamic = "force-dynamic";
 
-import { api, Invoice } from "../../lib/api";
+import Link from "next/link";
+
+import { MetricCard } from "../components/MetricCard";
+import { api, Invoice, MacroFinancials, PricingSuggestion, ProjectFinancials } from "../../lib/api";
 
 async function getInvoices(): Promise<Invoice[]> {
   return api.invoices();
+}
+
+async function getProjectFinancials(): Promise<ProjectFinancials[]> {
+  return api.projectFinancials();
+}
+
+async function getFinancialOverview(): Promise<MacroFinancials> {
+  return api.financialOverview();
+}
+
+async function getPricingSuggestions(): Promise<PricingSuggestion[]> {
+  return api.pricingSuggestions();
 }
 
 function statusTone(status: string): "default" | "success" | "warning" | "danger" {
@@ -19,49 +34,190 @@ function statusTone(status: string): "default" | "success" | "warning" | "danger
   }
 }
 
+function formatCurrency(value: number, currency = "USD"): string {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency,
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2
+  }).format(value);
+}
+
 export default async function FinancialsPage(): Promise<JSX.Element> {
-  const invoices = await getInvoices();
+  const [invoices, projectFinancials, overview, pricingSuggestions] = await Promise.all([
+    getInvoices(),
+    getProjectFinancials(),
+    getFinancialOverview(),
+    getPricingSuggestions()
+  ]);
 
   return (
     <div>
       <h2 className="section-title">Financial Control</h2>
-      <p className="text-muted" style={{ maxWidth: "680px" }}>
-        Invoices, payments, and expenses link directly to projects and clients to simplify billing accuracy and profitability
-        reporting.
+      <p className="text-muted" style={{ maxWidth: "720px" }}>
+        Cash flow clarity across projects, clients, and retained engagements. Track earnings, spending, and working capital
+        to keep teams and leadership aligned.
       </p>
-      <table className="table">
-        <thead>
-          <tr>
-            <th>Invoice</th>
-            <th>Client</th>
-            <th>Status</th>
-            <th>Issued</th>
-            <th>Due</th>
-            <th>Total</th>
-          </tr>
-        </thead>
-        <tbody>
-          {invoices.map((invoice) => (
-            <tr key={invoice.id}>
-              <td>{invoice.number}</td>
-              <td>{invoice.client_id}</td>
-              <td>
-                <span className={`badge ${statusTone(invoice.status)}`} style={{ textTransform: "uppercase" }}>
-                  {invoice.status}
-                </span>
-              </td>
-              <td>{new Date(invoice.issue_date).toLocaleDateString()}</td>
-              <td>{new Date(invoice.due_date).toLocaleDateString()}</td>
-              <td>
-                {`$${invoice.items.reduce((acc, item) => acc + item.total, 0).toLocaleString(undefined, {
-                  minimumFractionDigits: 2,
-                  maximumFractionDigits: 2
-                })}`}
-              </td>
+
+      <div className="card-grid" style={{ marginTop: "2rem", marginBottom: "2rem" }}>
+        <MetricCard title="Total invoiced" value={formatCurrency(overview.total_invoiced)} helper="Lifetime billings" />
+        <MetricCard
+          title="Collected"
+          value={formatCurrency(overview.total_collected)}
+          helper="Cash received"
+          tone="success"
+        />
+        <MetricCard
+          title="Outstanding"
+          value={formatCurrency(overview.total_outstanding)}
+          helper="Awaiting collection"
+          tone={overview.total_outstanding > 0 ? "warning" : "success"}
+        />
+        <MetricCard
+          title="Expenses"
+          value={formatCurrency(overview.total_expenses)}
+          helper="Direct project costs"
+          tone="warning"
+        />
+        <MetricCard
+          title="Net cash flow"
+          value={formatCurrency(overview.net_cash_flow)}
+          helper="Collected minus spend"
+          tone={overview.net_cash_flow >= 0 ? "success" : "danger"}
+        />
+      </div>
+
+      <section style={{ marginTop: "2rem" }}>
+        <h3 style={{ marginBottom: "0.5rem" }}>Project-level income &amp; spending</h3>
+        <p className="text-muted" style={{ maxWidth: "680px" }}>
+          Compare revenue collected against direct delivery costs to understand margin performance by engagement.
+        </p>
+        <table className="table">
+          <thead>
+            <tr>
+              <th>Project</th>
+              <th>Client</th>
+              <th>Invoiced</th>
+              <th>Collected</th>
+              <th>Expenses</th>
+              <th>Outstanding</th>
+              <th>Net</th>
             </tr>
-          ))}
-        </tbody>
-      </table>
+          </thead>
+          <tbody>
+            {projectFinancials.map((record) => (
+              <tr key={record.project_id}>
+                <td>{record.project_name}</td>
+                <td>{record.client_name ?? "—"}</td>
+                <td>{formatCurrency(record.total_invoiced, record.currency)}</td>
+                <td>{formatCurrency(record.total_collected, record.currency)}</td>
+                <td>{formatCurrency(record.total_expenses, record.currency)}</td>
+                <td style={{ color: record.outstanding_amount > 0 ? "#facc15" : "#94a3b8" }}>
+                  {formatCurrency(record.outstanding_amount, record.currency)}
+                </td>
+                <td style={{ color: record.net_revenue >= 0 ? "#4ade80" : "#f87171" }}>
+                  {formatCurrency(record.net_revenue, record.currency)}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </section>
+
+      <section style={{ marginTop: "3rem" }}>
+        <h3 style={{ marginBottom: "0.5rem" }}>Invoice ledger</h3>
+        <p className="text-muted" style={{ maxWidth: "680px" }}>
+          Detailed view of invoices across all projects, including issued and due dates to support collections follow-up.
+        </p>
+        <table className="table">
+          <thead>
+            <tr>
+              <th>Invoice</th>
+              <th>Client</th>
+              <th>Status</th>
+              <th>Issued</th>
+              <th>Due</th>
+              <th>Total</th>
+            </tr>
+          </thead>
+          <tbody>
+            {invoices.map((invoice) => (
+              <tr key={invoice.id}>
+                <td>{invoice.number}</td>
+                <td>{invoice.client_id}</td>
+                <td>
+                  <span className={`badge ${statusTone(invoice.status)}`} style={{ textTransform: "uppercase" }}>
+                    {invoice.status}
+                  </span>
+                </td>
+                <td>{new Date(invoice.issue_date).toLocaleDateString()}</td>
+                <td>{new Date(invoice.due_date).toLocaleDateString()}</td>
+                <td>{formatCurrency(invoice.items.reduce((acc, item) => acc + item.total, 0), invoice.currency)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </section>
+
+      <section style={{ marginTop: "3rem" }}>
+        <h3 style={{ marginBottom: "0.5rem" }}>Pricing insights</h3>
+        <p className="text-muted" style={{ maxWidth: "680px" }}>
+          Use contribution margins to guide retainers and project proposals. Suggestions factor in delivery costs and target
+          profitability thresholds.
+        </p>
+        <table className="table">
+          <thead>
+            <tr>
+              <th>Service</th>
+              <th>Current rate</th>
+              <th>Recommended rate</th>
+              <th>Margin</th>
+              <th>Adjustment</th>
+              <th>Guidance</th>
+            </tr>
+          </thead>
+          <tbody>
+            {pricingSuggestions.length === 0 ? (
+              <tr>
+                <td colSpan={6} style={{ textAlign: "center", color: "#94a3b8" }}>
+                  No pricing suggestions available yet. Add financial data to generate insights.
+                </td>
+              </tr>
+            ) : (
+              pricingSuggestions.map((suggestion) => (
+                <tr key={suggestion.project_id}>
+                  <td>{suggestion.service}</td>
+                  <td>{formatCurrency(suggestion.current_rate, suggestion.currency)}</td>
+                  <td>{formatCurrency(suggestion.recommended_rate, suggestion.currency)}</td>
+                  <td>{suggestion.current_margin.toFixed(1)}%</td>
+                  <td>
+                    {suggestion.recommended_adjustment_pct >= 0
+                      ? `+${suggestion.recommended_adjustment_pct.toFixed(1)}%`
+                      : `${suggestion.recommended_adjustment_pct.toFixed(1)}%`}
+                  </td>
+                  <td style={{ maxWidth: "320px" }}>{suggestion.rationale}</td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </section>
+
+      <div style={{ marginTop: "3rem" }}>
+        <Link
+          href="/financials/tax-calculator"
+          style={{
+            display: "inline-flex",
+            alignItems: "center",
+            gap: "0.5rem",
+            color: "#38bdf8",
+            fontWeight: 600,
+            textDecoration: "none"
+          }}
+        >
+          Open Philippines tax calculator →
+        </Link>
+      </div>
     </div>
   );
 }

--- a/frontend/app/financials/tax-calculator/page.tsx
+++ b/frontend/app/financials/tax-calculator/page.tsx
@@ -1,0 +1,420 @@
+"use client";
+
+import Link from "next/link";
+import type { Dispatch, SetStateAction } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import {
+  api,
+  DeductionOpportunity,
+  TaxComputationPayload,
+  TaxComputationResult,
+  TaxEntryInput
+} from "../../../lib/api";
+
+type Entry = TaxEntryInput & { id: string };
+
+function generateId(): string {
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+    return crypto.randomUUID();
+  }
+  return Math.random().toString(36).slice(2);
+}
+
+const defaultIncomes: Entry[] = [
+  { id: generateId(), label: "Service retainers", amount: 1_800_000 },
+  { id: generateId(), label: "Consulting projects", amount: 420_000 }
+];
+
+const defaultCostOfSales: Entry[] = [
+  { id: generateId(), label: "Production subcontractors", amount: 360_000 },
+  { id: generateId(), label: "Materials & hosting", amount: 95_000 }
+];
+
+const defaultOperatingExpenses: Entry[] = [
+  { id: generateId(), label: "Studio rent", amount: 180_000 },
+  { id: generateId(), label: "Team salaries", amount: 420_000 },
+  { id: generateId(), label: "Utilities & internet", amount: 48_000 }
+];
+
+const defaultDeductions: Entry[] = [
+  { id: generateId(), label: "PhilHealth", amount: 36_000 },
+  { id: generateId(), label: "Pag-IBIG", amount: 18_000 }
+];
+
+function formatCurrency(value: number): string {
+  return new Intl.NumberFormat("en-PH", {
+    style: "currency",
+    currency: "PHP",
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2
+  }).format(Number.isFinite(value) ? value : 0);
+}
+
+function sanitizeEntries(entries: Entry[]): TaxEntryInput[] {
+  return entries.map((entry) => ({
+    label: entry.label.trim() || "Untitled",
+    amount: Number.isFinite(entry.amount) ? Math.max(entry.amount, 0) : 0
+  }));
+}
+
+function EntryList({
+  title,
+  description,
+  entries,
+  onChange,
+  onAdd,
+  onRemove
+}: {
+  title: string;
+  description: string;
+  entries: Entry[];
+  onChange: (id: string, field: "label" | "amount", value: string) => void;
+  onAdd: () => void;
+  onRemove: (id: string) => void;
+}): JSX.Element {
+  return (
+    <div className="card" style={{ display: "flex", flexDirection: "column", gap: "1rem" }}>
+      <div>
+        <h3 style={{ margin: 0 }}>{title}</h3>
+        <p className="text-muted" style={{ margin: 0, fontSize: "0.9rem" }}>
+          {description}
+        </p>
+      </div>
+      {entries.map((entry) => (
+        <div key={entry.id} style={{ display: "grid", gridTemplateColumns: "1fr 160px 32px", gap: "0.75rem", alignItems: "center" }}>
+          <input
+            type="text"
+            value={entry.label}
+            placeholder="Label"
+            onChange={(event) => onChange(entry.id, "label", event.target.value)}
+            style={{
+              padding: "0.75rem",
+              borderRadius: "0.75rem",
+              border: "1px solid rgba(148,163,184,0.2)",
+              background: "rgba(15,23,42,0.6)",
+              color: "#e2e8f0"
+            }}
+          />
+          <input
+            type="number"
+            min={0}
+            value={entry.amount}
+            onChange={(event) => onChange(entry.id, "amount", event.target.value)}
+            style={{
+              padding: "0.75rem",
+              borderRadius: "0.75rem",
+              border: "1px solid rgba(148,163,184,0.2)",
+              background: "rgba(15,23,42,0.6)",
+              color: "#e2e8f0"
+            }}
+          />
+          <button
+            type="button"
+            onClick={() => onRemove(entry.id)}
+            aria-label={`Remove ${entry.label}`}
+            style={{
+              border: "none",
+              background: "transparent",
+              color: "#94a3b8",
+              fontSize: "1.25rem",
+              cursor: "pointer"
+            }}
+          >
+            ×
+          </button>
+        </div>
+      ))}
+      <button
+        type="button"
+        onClick={onAdd}
+        style={{
+          padding: "0.75rem 1rem",
+          borderRadius: "0.75rem",
+          border: "1px solid rgba(56,189,248,0.4)",
+          background: "transparent",
+          color: "#38bdf8",
+          fontWeight: 600,
+          cursor: "pointer"
+        }}
+      >
+        + Add entry
+      </button>
+    </div>
+  );
+}
+
+export default function TaxCalculatorPage(): JSX.Element {
+  const [incomes, setIncomes] = useState<Entry[]>(defaultIncomes);
+  const [costOfSales, setCostOfSales] = useState<Entry[]>(defaultCostOfSales);
+  const [operatingExpenses, setOperatingExpenses] = useState<Entry[]>(defaultOperatingExpenses);
+  const [otherDeductions, setOtherDeductions] = useState<Entry[]>(defaultDeductions);
+  const [applyPercentageTax, setApplyPercentageTax] = useState<boolean>(true);
+  const [percentageTaxRate, setPercentageTaxRate] = useState<number>(3);
+  const [vatRegistered, setVatRegistered] = useState<boolean>(false);
+  const [calculation, setCalculation] = useState<TaxComputationResult | null>(null);
+  const [loading, setLoading] = useState<boolean>(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const totalIncome = useMemo(() => incomes.reduce((sum, entry) => sum + (Number.isFinite(entry.amount) ? entry.amount : 0), 0), [incomes]);
+  const totalExpenses = useMemo(
+    () =>
+      costOfSales.concat(operatingExpenses).reduce((sum, entry) => sum + (Number.isFinite(entry.amount) ? entry.amount : 0), 0),
+    [costOfSales, operatingExpenses]
+  );
+  const totalDeductions = useMemo(
+    () => otherDeductions.reduce((sum, entry) => sum + (Number.isFinite(entry.amount) ? entry.amount : 0), 0),
+    [otherDeductions]
+  );
+
+  const handleEntryChange = useCallback(
+    (setState: Dispatch<SetStateAction<Entry[]>>) =>
+      (id: string, field: "label" | "amount", value: string) => {
+        setState((prev) =>
+          prev.map((entry) => {
+            if (entry.id !== id) {
+              return entry;
+            }
+            if (field === "amount") {
+              const parsed = Number(value);
+              return { ...entry, amount: Number.isFinite(parsed) ? parsed : 0 };
+            }
+            return { ...entry, label: value };
+          })
+        );
+      },
+    []
+  );
+
+  const handleEntryAdd = useCallback(
+    (setState: Dispatch<SetStateAction<Entry[]>>) => () => {
+      setState((prev) => [...prev, { id: generateId(), label: "", amount: 0 }]);
+    },
+    []
+  );
+
+  const handleEntryRemove = useCallback(
+    (setState: Dispatch<SetStateAction<Entry[]>>) => (id: string) => {
+      setState((prev) => prev.filter((entry) => entry.id !== id));
+    },
+    []
+  );
+
+  const recalculate = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const payload: TaxComputationPayload = {
+        incomes: sanitizeEntries(incomes),
+        cost_of_sales: sanitizeEntries(costOfSales),
+        operating_expenses: sanitizeEntries(operatingExpenses),
+        other_deductions: sanitizeEntries(otherDeductions),
+        apply_percentage_tax: applyPercentageTax,
+        percentage_tax_rate: percentageTaxRate,
+        vat_registered: vatRegistered
+      };
+      const result = await api.computeTax(payload);
+      setCalculation(result);
+    } catch (thrown) {
+      console.error(thrown);
+      setError("Unable to calculate taxes right now. Please try again.");
+    } finally {
+      setLoading(false);
+    }
+  }, [applyPercentageTax, costOfSales, incomes, operatingExpenses, otherDeductions, percentageTaxRate, vatRegistered]);
+
+  useEffect(() => {
+    void recalculate();
+  }, [recalculate]);
+
+  const deductionOpportunities: DeductionOpportunity[] = calculation?.deduction_opportunities ?? [];
+
+  return (
+    <div>
+      <Link href="/financials" style={{ color: "#38bdf8", textDecoration: "none", fontWeight: 600 }}>
+        ← Back to financial control
+      </Link>
+      <h2 className="section-title" style={{ marginTop: "1.5rem" }}>
+        Philippines Individual Company Tax Automation
+      </h2>
+      <p className="text-muted" style={{ maxWidth: "720px" }}>
+        Capture every peso of revenue, expenses, and allowable deductions to automate Philippine income tax, percentage tax,
+        and VAT projections. Use the planner to stay compliant with TRAIN law while maximizing cash for growth.
+      </p>
+
+      <div className="grid-two" style={{ marginTop: "2rem", gap: "1.5rem" }}>
+        <EntryList
+          title="Income sources"
+          description="List all annual revenue streams including retainers, project work, and product sales."
+          entries={incomes}
+          onChange={handleEntryChange(setIncomes)}
+          onAdd={handleEntryAdd(setIncomes)}
+          onRemove={handleEntryRemove(setIncomes)}
+        />
+        <EntryList
+          title="Direct costs"
+          description="Capture cost of sales such as subcontractors, production, and other delivery expenses."
+          entries={costOfSales}
+          onChange={handleEntryChange(setCostOfSales)}
+          onAdd={handleEntryAdd(setCostOfSales)}
+          onRemove={handleEntryRemove(setCostOfSales)}
+        />
+      </div>
+
+      <div className="grid-two" style={{ marginTop: "1.5rem", gap: "1.5rem" }}>
+        <EntryList
+          title="Operating expenses"
+          description="Administrative overhead like rent, salaries, utilities, insurance, and marketing."
+          entries={operatingExpenses}
+          onChange={handleEntryChange(setOperatingExpenses)}
+          onAdd={handleEntryAdd(setOperatingExpenses)}
+          onRemove={handleEntryRemove(setOperatingExpenses)}
+        />
+        <EntryList
+          title="Allowable deductions"
+          description="Government contributions and other deductions that lower taxable income."
+          entries={otherDeductions}
+          onChange={handleEntryChange(setOtherDeductions)}
+          onAdd={handleEntryAdd(setOtherDeductions)}
+          onRemove={handleEntryRemove(setOtherDeductions)}
+        />
+      </div>
+
+      <div className="card" style={{ marginTop: "2rem", display: "flex", flexDirection: "column", gap: "1rem" }}>
+        <h3 style={{ margin: 0 }}>Tax configuration</h3>
+        <label style={{ display: "flex", alignItems: "center", gap: "0.75rem" }}>
+          <input
+            type="checkbox"
+            checked={applyPercentageTax}
+            onChange={(event) => setApplyPercentageTax(event.target.checked)}
+          />
+          <span>Apply percentage tax on gross receipts</span>
+        </label>
+        {applyPercentageTax && (
+          <label style={{ display: "flex", flexDirection: "column", gap: "0.25rem", maxWidth: "320px" }}>
+            <span className="text-muted">Percentage tax rate</span>
+            <select
+              value={percentageTaxRate}
+              onChange={(event) => setPercentageTaxRate(Number(event.target.value))}
+              style={{
+                padding: "0.75rem",
+                borderRadius: "0.75rem",
+                border: "1px solid rgba(148,163,184,0.2)",
+                background: "rgba(15,23,42,0.6)",
+                color: "#e2e8f0"
+              }}
+            >
+              <option value={1}>1% (CREATE relief for MSMEs)</option>
+              <option value={3}>3% standard percentage tax</option>
+            </select>
+          </label>
+        )}
+        <label style={{ display: "flex", alignItems: "center", gap: "0.75rem" }}>
+          <input type="checkbox" checked={vatRegistered} onChange={(event) => setVatRegistered(event.target.checked)} />
+          <span>VAT registered (12% on gross sales)</span>
+        </label>
+        <button
+          type="button"
+          onClick={() => void recalculate()}
+          disabled={loading}
+          style={{
+            alignSelf: "flex-start",
+            padding: "0.85rem 1.5rem",
+            borderRadius: "0.75rem",
+            border: "none",
+            background: loading ? "rgba(148,163,184,0.4)" : "#38bdf8",
+            color: loading ? "#0f172a" : "#0f172a",
+            fontWeight: 700,
+            cursor: loading ? "not-allowed" : "pointer"
+          }}
+        >
+          {loading ? "Calculating…" : "Recalculate tax obligations"}
+        </button>
+        {error && <p style={{ color: "#f87171", margin: 0 }}>{error}</p>}
+      </div>
+
+      <div className="card" style={{ marginTop: "2.5rem", display: "flex", flexDirection: "column", gap: "1rem" }}>
+        <h3 style={{ margin: 0 }}>Financial snapshot</h3>
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))", gap: "1rem" }}>
+          <div>
+            <p className="text-muted" style={{ margin: 0 }}>Total income</p>
+            <p style={{ fontSize: "1.4rem", margin: "0.25rem 0" }}>{formatCurrency(totalIncome)}</p>
+          </div>
+          <div>
+            <p className="text-muted" style={{ margin: 0 }}>Total expenses</p>
+            <p style={{ fontSize: "1.4rem", margin: "0.25rem 0", color: "#f97316" }}>{formatCurrency(totalExpenses)}</p>
+          </div>
+          <div>
+            <p className="text-muted" style={{ margin: 0 }}>Allowable deductions</p>
+            <p style={{ fontSize: "1.4rem", margin: "0.25rem 0", color: "#facc15" }}>{formatCurrency(totalDeductions)}</p>
+          </div>
+          <div>
+            <p className="text-muted" style={{ margin: 0 }}>Projected taxable income</p>
+            <p style={{ fontSize: "1.4rem", margin: "0.25rem 0" }}>
+              {formatCurrency(calculation?.taxable_income ?? Math.max(totalIncome - totalExpenses - totalDeductions, 0))}
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {calculation && (
+        <div className="card" style={{ marginTop: "2.5rem", display: "flex", flexDirection: "column", gap: "0.75rem" }}>
+          <h3 style={{ margin: 0 }}>Automated tax breakdown</h3>
+          <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(200px, 1fr))", gap: "1rem" }}>
+            <div>
+              <p className="text-muted" style={{ margin: 0 }}>Income tax</p>
+              <p style={{ fontSize: "1.5rem", margin: "0.25rem 0", color: "#f97316" }}>
+                {formatCurrency(calculation.income_tax)}
+              </p>
+            </div>
+            <div>
+              <p className="text-muted" style={{ margin: 0 }}>Percentage tax</p>
+              <p style={{ fontSize: "1.5rem", margin: "0.25rem 0", color: "#facc15" }}>
+                {formatCurrency(calculation.percentage_tax)}
+              </p>
+            </div>
+            <div>
+              <p className="text-muted" style={{ margin: 0 }}>VAT due</p>
+              <p style={{ fontSize: "1.5rem", margin: "0.25rem 0", color: "#38bdf8" }}>
+                {formatCurrency(calculation.vat_due)}
+              </p>
+            </div>
+            <div>
+              <p className="text-muted" style={{ margin: 0 }}>Total estimated tax</p>
+              <p style={{ fontSize: "1.5rem", margin: "0.25rem 0", color: "#f87171" }}>
+                {formatCurrency(calculation.total_tax)}
+              </p>
+            </div>
+            <div>
+              <p className="text-muted" style={{ margin: 0 }}>Effective tax rate</p>
+              <p style={{ fontSize: "1.5rem", margin: "0.25rem 0" }}>{calculation.effective_tax_rate.toFixed(2)}%</p>
+            </div>
+          </div>
+          <p className="text-muted" style={{ margin: 0, fontSize: "0.85rem" }}>
+            Figures assume compliance with Bureau of Internal Revenue requirements under the TRAIN law. Cross-check with a
+            licensed tax professional prior to filing.
+          </p>
+        </div>
+      )}
+
+      {deductionOpportunities.length > 0 && (
+        <div className="card" style={{ marginTop: "2.5rem", display: "flex", flexDirection: "column", gap: "0.75rem" }}>
+          <h3 style={{ margin: 0 }}>Deduction opportunities</h3>
+          <p className="text-muted" style={{ margin: 0 }}>
+            Strengthen deduction compliance and documentation using the reminders below.
+          </p>
+          <ul style={{ margin: 0, paddingLeft: "1.25rem", display: "flex", flexDirection: "column", gap: "0.5rem" }}>
+            {deductionOpportunities.map((tip) => (
+              <li key={tip.category} style={{ lineHeight: 1.5 }}>
+                <strong style={{ textTransform: "uppercase", letterSpacing: "0.05em", fontSize: "0.75rem" }}>
+                  {tip.category}
+                </strong>
+                <p style={{ margin: "0.25rem 0 0", color: "#cbd5f5" }}>{tip.message}</p>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -25,6 +25,14 @@ export const api = {
   projects: () => request<Project[]>("/projects"),
   clients: () => request<Client[]>("/clients"),
   invoices: () => request<Invoice[]>("/financials/invoices"),
+  financialOverview: () => request<MacroFinancials>("/financials/overview"),
+  projectFinancials: () => request<ProjectFinancials[]>("/financials/projects"),
+  pricingSuggestions: () => request<PricingSuggestion[]>("/financials/pricing/suggestions"),
+  computeTax: (payload: TaxComputationPayload) =>
+    request<TaxComputationResult>("/financials/tax/compute", {
+      method: "POST",
+      body: JSON.stringify(payload)
+    }),
   supportTickets: () => request<Ticket[]>("/support/tickets"),
   employees: () => request<Employee[]>("/hr/employees"),
   campaigns: () => request<Campaign[]>("/marketing/campaigns"),
@@ -120,6 +128,71 @@ export interface Invoice {
   issue_date: string;
   due_date: string;
   items: LineItem[];
+}
+
+export interface ProjectFinancials {
+  project_id: string;
+  project_name: string;
+  client_name?: string | null;
+  currency: string;
+  total_invoiced: number;
+  total_collected: number;
+  total_expenses: number;
+  outstanding_amount: number;
+  net_revenue: number;
+}
+
+export interface MacroFinancials {
+  total_invoiced: number;
+  total_collected: number;
+  total_outstanding: number;
+  total_expenses: number;
+  net_cash_flow: number;
+}
+
+export interface TaxEntryInput {
+  label: string;
+  amount: number;
+}
+
+export interface TaxComputationPayload {
+  incomes: TaxEntryInput[];
+  cost_of_sales: TaxEntryInput[];
+  operating_expenses: TaxEntryInput[];
+  other_deductions: TaxEntryInput[];
+  apply_percentage_tax: boolean;
+  percentage_tax_rate: number;
+  vat_registered: boolean;
+}
+
+export interface DeductionOpportunity {
+  category: string;
+  message: string;
+}
+
+export interface TaxComputationResult {
+  gross_revenue: number;
+  total_cost_of_sales: number;
+  total_operating_expenses: number;
+  total_other_deductions: number;
+  taxable_income: number;
+  income_tax: number;
+  percentage_tax: number;
+  vat_due: number;
+  total_tax: number;
+  effective_tax_rate: number;
+  deduction_opportunities: DeductionOpportunity[];
+}
+
+export interface PricingSuggestion {
+  project_id: string;
+  service: string;
+  current_rate: number;
+  recommended_rate: number;
+  current_margin: number;
+  recommended_adjustment_pct: number;
+  rationale: string;
+  currency: string;
 }
 
 export interface LineItem {


### PR DESCRIPTION
## Summary
- add tax computation request/response models, pricing suggestion rollups, and new financial API routes
- cover financial endpoints with regression tests for tax math and pricing guidance
- expose pricing guidance on the financials dashboard and rebuild the Philippines tax planner with dynamic inputs and backend automation

## Testing
- pytest
- npm run lint --prefix frontend

------
https://chatgpt.com/codex/tasks/task_e_68d2ff082b0c8333a84c854f5e7f9319