### PR TITLE
Add client detail view and creation workflow

### DIFF
--- a/frontend/app/clients/ClientsTable.tsx
+++ b/frontend/app/clients/ClientsTable.tsx
@@ -1,0 +1,528 @@
+"use client";
+
+import { FormEvent, useMemo, useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+
+import {
+  api,
+  Client,
+  ClientCreateRequest,
+  ClientSegment,
+  ContactInput,
+  Industry,
+  InteractionChannel
+} from "../../lib/api";
+
+interface ClientsTableProps {
+  clients: Client[];
+}
+
+interface ClientFormState {
+  organization_name: string;
+  industry: Industry;
+  segment: ClientSegment;
+  billing_email: string;
+  preferred_channel: InteractionChannel;
+  timezone: string;
+  contact: {
+    first_name: string;
+    last_name: string;
+    email: string;
+    phone: string;
+    title: string;
+  };
+  project: {
+    name: string;
+    project_type: string;
+    start_date: string;
+    manager_id: string;
+    budget: string;
+    currency: string;
+    start_after: string;
+  };
+}
+
+const industryOptions: { label: string; value: Industry }[] = [
+  { label: "Hospitality", value: "hospitality" },
+  { label: "Creative", value: "creative" },
+  { label: "Technology", value: "technology" },
+  { label: "Other", value: "other" }
+];
+
+const segmentOptions: { label: string; value: ClientSegment }[] = [
+  { label: "Retainer", value: "retainer" },
+  { label: "Project", value: "project" },
+  { label: "VIP", value: "vip" },
+  { label: "Prospect", value: "prospect" }
+];
+
+const channelOptions: { label: string; value: InteractionChannel }[] = [
+  { label: "Email", value: "email" },
+  { label: "Client Portal", value: "portal" },
+  { label: "Social", value: "social" },
+  { label: "Phone", value: "phone" }
+];
+
+const projectTemplateOptions = [
+  { label: "Website", value: "website" },
+  { label: "Branding", value: "branding" },
+  { label: "Consulting", value: "consulting" }
+];
+
+function initialFormState(): ClientFormState {
+  return {
+    organization_name: "",
+    industry: "hospitality",
+    segment: "retainer",
+    billing_email: "",
+    preferred_channel: "email",
+    timezone: "UTC",
+    contact: {
+      first_name: "",
+      last_name: "",
+      email: "",
+      phone: "",
+      title: ""
+    },
+    project: {
+      name: "",
+      project_type: "website",
+      start_date: "",
+      manager_id: "",
+      budget: "",
+      currency: "USD",
+      start_after: ""
+    }
+  };
+}
+
+export function ClientsTable({ clients }: ClientsTableProps): JSX.Element {
+  const router = useRouter();
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [formState, setFormState] = useState<ClientFormState>(initialFormState);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+
+  const canSubmit = useMemo(() => {
+    const { organization_name, billing_email, project } = formState;
+    return Boolean(
+      organization_name &&
+      billing_email &&
+      project.name &&
+      project.project_type &&
+      project.start_date &&
+      project.manager_id &&
+      project.budget
+    );
+  }, [formState]);
+
+  const handleClose = () => {
+    setIsModalOpen(false);
+    setFormState(initialFormState());
+    setError(null);
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (isSubmitting || !canSubmit) {
+      return;
+    }
+
+    setIsSubmitting(true);
+    setError(null);
+
+    try {
+      const contactInput = formState.contact;
+      const contacts: ContactInput[] = contactInput.email
+        ? [
+            {
+              first_name: contactInput.first_name,
+              last_name: contactInput.last_name,
+              email: contactInput.email,
+              phone: contactInput.phone || null,
+              title: contactInput.title || null
+            }
+          ]
+        : [];
+
+      const payload: ClientCreateRequest = {
+        organization_name: formState.organization_name,
+        industry: formState.industry,
+        segment: formState.segment,
+        billing_email: formState.billing_email,
+        preferred_channel: formState.preferred_channel,
+        timezone: formState.timezone,
+        contacts,
+        projects: [
+          {
+            name: formState.project.name,
+            project_type: formState.project.project_type,
+            start_date: new Date(`${formState.project.start_date}T00:00:00Z`).toISOString(),
+            manager_id: formState.project.manager_id,
+            budget: Number(formState.project.budget),
+            currency: formState.project.currency,
+            start_after: formState.project.start_after || null
+          }
+        ]
+      };
+
+      await api.createClient(payload);
+      setSuccessMessage("Client successfully created.");
+      setTimeout(() => setSuccessMessage(null), 5000);
+      handleClose();
+      router.refresh();
+    } catch (submitError) {
+      if (submitError instanceof Error) {
+        setError(submitError.message);
+      } else {
+        setError("Unable to save the client. Please try again.");
+      }
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div>
+      <div className="clients-toolbar">
+        <button className="button primary" onClick={() => setIsModalOpen(true)}>
+          + Add Client
+        </button>
+        {successMessage && <span className="form-feedback success">{successMessage}</span>}
+      </div>
+      <table className="table">
+        <thead>
+          <tr>
+            <th>Organization</th>
+            <th>Industry</th>
+            <th>Segment</th>
+            <th>Billing Email</th>
+            <th>Timezone</th>
+          </tr>
+        </thead>
+        <tbody>
+          {clients.map((client) => (
+            <tr
+              key={client.id}
+              className="clickable-row"
+              onClick={() => router.push(`/clients/${client.id}`)}
+            >
+              <td>
+                <Link href={`/clients/${client.id}`} onClick={(event) => event.stopPropagation()}>
+                  {client.organization_name}
+                </Link>
+              </td>
+              <td style={{ textTransform: "capitalize" }}>{client.industry}</td>
+              <td>
+                <span
+                  className={`badge ${client.segment === "retainer" ? "success" : client.segment === "vip" ? "warning" : ""}`}
+                  style={{ textTransform: "uppercase", letterSpacing: "0.08em" }}
+                >
+                  {client.segment}
+                </span>
+              </td>
+              <td>{client.billing_email}</td>
+              <td>{client.timezone}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      {isModalOpen && (
+        <div className="modal-backdrop" role="presentation" onClick={handleClose}>
+          <div className="modal" role="dialog" aria-modal="true" onClick={(event) => event.stopPropagation()}>
+            <div className="modal-header">
+              <h3>New Client</h3>
+              <button className="button ghost" onClick={handleClose}>
+                Close
+              </button>
+            </div>
+            <form className="form" onSubmit={handleSubmit}>
+              <fieldset className="form-section">
+                <legend>Organization</legend>
+                <div className="form-grid">
+                  <label>
+                    <span>Organization name</span>
+                    <input
+                      type="text"
+                      value={formState.organization_name}
+                      onChange={(event) =>
+                        setFormState((prev) => ({ ...prev, organization_name: event.target.value }))
+                      }
+                      required
+                    />
+                  </label>
+                  <label>
+                    <span>Billing email</span>
+                    <input
+                      type="email"
+                      value={formState.billing_email}
+                      onChange={(event) =>
+                        setFormState((prev) => ({ ...prev, billing_email: event.target.value }))
+                      }
+                      required
+                    />
+                  </label>
+                  <label>
+                    <span>Industry</span>
+                    <select
+                      value={formState.industry}
+                      onChange={(event) =>
+                        setFormState((prev) => ({ ...prev, industry: event.target.value as Industry }))
+                      }
+                    >
+                      {industryOptions.map((option) => (
+                        <option key={option.value} value={option.value}>
+                          {option.label}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                  <label>
+                    <span>Segment</span>
+                    <select
+                      value={formState.segment}
+                      onChange={(event) =>
+                        setFormState((prev) => ({ ...prev, segment: event.target.value as ClientSegment }))
+                      }
+                    >
+                      {segmentOptions.map((option) => (
+                        <option key={option.value} value={option.value}>
+                          {option.label}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                  <label>
+                    <span>Preferred channel</span>
+                    <select
+                      value={formState.preferred_channel}
+                      onChange={(event) =>
+                        setFormState((prev) => ({
+                          ...prev,
+                          preferred_channel: event.target.value as InteractionChannel
+                        }))
+                      }
+                    >
+                      {channelOptions.map((option) => (
+                        <option key={option.value} value={option.value}>
+                          {option.label}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                  <label>
+                    <span>Timezone</span>
+                    <input
+                      type="text"
+                      value={formState.timezone}
+                      onChange={(event) =>
+                        setFormState((prev) => ({ ...prev, timezone: event.target.value }))
+                      }
+                      placeholder="e.g. America/New_York"
+                    />
+                  </label>
+                </div>
+              </fieldset>
+
+              <fieldset className="form-section">
+                <legend>Primary contact</legend>
+                <div className="form-grid">
+                  <label>
+                    <span>First name</span>
+                    <input
+                      type="text"
+                      value={formState.contact.first_name}
+                      onChange={(event) =>
+                        setFormState((prev) => ({
+                          ...prev,
+                          contact: { ...prev.contact, first_name: event.target.value }
+                        }))
+                      }
+                    />
+                  </label>
+                  <label>
+                    <span>Last name</span>
+                    <input
+                      type="text"
+                      value={formState.contact.last_name}
+                      onChange={(event) =>
+                        setFormState((prev) => ({
+                          ...prev,
+                          contact: { ...prev.contact, last_name: event.target.value }
+                        }))
+                      }
+                    />
+                  </label>
+                  <label>
+                    <span>Email</span>
+                    <input
+                      type="email"
+                      value={formState.contact.email}
+                      onChange={(event) =>
+                        setFormState((prev) => ({
+                          ...prev,
+                          contact: { ...prev.contact, email: event.target.value }
+                        }))
+                      }
+                    />
+                  </label>
+                  <label>
+                    <span>Phone</span>
+                    <input
+                      type="tel"
+                      value={formState.contact.phone}
+                      onChange={(event) =>
+                        setFormState((prev) => ({
+                          ...prev,
+                          contact: { ...prev.contact, phone: event.target.value }
+                        }))
+                      }
+                      placeholder="Optional"
+                    />
+                  </label>
+                  <label>
+                    <span>Title</span>
+                    <input
+                      type="text"
+                      value={formState.contact.title}
+                      onChange={(event) =>
+                        setFormState((prev) => ({
+                          ...prev,
+                          contact: { ...prev.contact, title: event.target.value }
+                        }))
+                      }
+                      placeholder="Optional"
+                    />
+                  </label>
+                </div>
+              </fieldset>
+
+              <fieldset className="form-section">
+                <legend>Initial project</legend>
+                <div className="form-grid">
+                  <label>
+                    <span>Project name</span>
+                    <input
+                      type="text"
+                      value={formState.project.name}
+                      onChange={(event) =>
+                        setFormState((prev) => ({
+                          ...prev,
+                          project: { ...prev.project, name: event.target.value }
+                        }))
+                      }
+                      required
+                    />
+                  </label>
+                  <label>
+                    <span>Project type</span>
+                    <select
+                      value={formState.project.project_type}
+                      onChange={(event) =>
+                        setFormState((prev) => ({
+                          ...prev,
+                          project: { ...prev.project, project_type: event.target.value }
+                        }))
+                      }
+                    >
+                      {projectTemplateOptions.map((option) => (
+                        <option key={option.value} value={option.value}>
+                          {option.label}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                  <label>
+                    <span>Start date</span>
+                    <input
+                      type="date"
+                      value={formState.project.start_date}
+                      onChange={(event) =>
+                        setFormState((prev) => ({
+                          ...prev,
+                          project: { ...prev.project, start_date: event.target.value }
+                        }))
+                      }
+                      required
+                    />
+                  </label>
+                  <label>
+                    <span>Project manager ID</span>
+                    <input
+                      type="text"
+                      value={formState.project.manager_id}
+                      onChange={(event) =>
+                        setFormState((prev) => ({
+                          ...prev,
+                          project: { ...prev.project, manager_id: event.target.value }
+                        }))
+                      }
+                      required
+                    />
+                  </label>
+                  <label>
+                    <span>Budget (USD)</span>
+                    <input
+                      type="number"
+                      min="0"
+                      step="0.01"
+                      value={formState.project.budget}
+                      onChange={(event) =>
+                        setFormState((prev) => ({
+                          ...prev,
+                          project: { ...prev.project, budget: event.target.value }
+                        }))
+                      }
+                      required
+                    />
+                  </label>
+                  <label>
+                    <span>Currency</span>
+                    <input
+                      type="text"
+                      value={formState.project.currency}
+                      onChange={(event) =>
+                        setFormState((prev) => ({
+                          ...prev,
+                          project: { ...prev.project, currency: event.target.value }
+                        }))
+                      }
+                    />
+                  </label>
+                  <label>
+                    <span>Starts after (optional dependency)</span>
+                    <input
+                      type="text"
+                      value={formState.project.start_after}
+                      onChange={(event) =>
+                        setFormState((prev) => ({
+                          ...prev,
+                          project: { ...prev.project, start_after: event.target.value }
+                        }))
+                      }
+                      placeholder="Name of prerequisite project"
+                    />
+                  </label>
+                </div>
+              </fieldset>
+
+              {error && <p className="form-feedback error">{error}</p>}
+
+              <div className="form-actions">
+                <button className="button ghost" type="button" onClick={handleClose}>
+                  Cancel
+                </button>
+                <button className="button primary" type="submit" disabled={!canSubmit || isSubmitting}>
+                  {isSubmitting ? "Saving..." : "Create client"}
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/app/clients/[clientId]/page.tsx
+++ b/frontend/app/clients/[clientId]/page.tsx
@@ -1,0 +1,243 @@
+export const dynamic = "force-dynamic";
+
+import Link from "next/link";
+import { notFound } from "next/navigation";
+
+import { api, ClientDashboard } from "../../../lib/api";
+
+interface ClientPageProps {
+  params: { clientId: string };
+}
+
+async function getClientDashboard(clientId: string): Promise<ClientDashboard | null> {
+  try {
+    return await api.clientDashboard(clientId);
+  } catch (error) {
+    console.error(error);
+    return null;
+  }
+}
+
+function formatDate(value?: string | null): string {
+  if (!value) return "-";
+  const date = new Date(value);
+  return new Intl.DateTimeFormat("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric"
+  }).format(date);
+}
+
+function formatCurrency(amount: number, currency = "USD"): string {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency
+  }).format(amount);
+}
+
+export default async function ClientDetailPage({ params }: ClientPageProps): Promise<JSX.Element> {
+  const dashboard = await getClientDashboard(params.clientId);
+
+  if (!dashboard) {
+    notFound();
+  }
+
+  const { client, projects, financials, support } = dashboard;
+
+  return (
+    <div className="client-detail">
+      <Link href="/clients" className="back-link">
+        ← Back to clients
+      </Link>
+      <h1 className="section-title">{client.organization_name}</h1>
+      <p className="text-muted" style={{ maxWidth: "760px" }}>
+        Centralized intelligence for {client.organization_name}. Review project delivery, revenue health, and active support
+        engagements to stay ahead of client expectations.
+      </p>
+
+      <div className="card-grid detail-cards">
+        <div className="card">
+          <h3>Client profile</h3>
+          <dl className="definition-list">
+            <div>
+              <dt>Industry</dt>
+              <dd style={{ textTransform: "capitalize" }}>{client.industry}</dd>
+            </div>
+            <div>
+              <dt>Segment</dt>
+              <dd style={{ textTransform: "uppercase", letterSpacing: "0.08em" }}>{client.segment}</dd>
+            </div>
+            <div>
+              <dt>Billing email</dt>
+              <dd>{client.billing_email}</dd>
+            </div>
+            <div>
+              <dt>Preferred channel</dt>
+              <dd style={{ textTransform: "capitalize" }}>{client.preferred_channel}</dd>
+            </div>
+            <div>
+              <dt>Timezone</dt>
+              <dd>{client.timezone}</dd>
+            </div>
+          </dl>
+          {client.contacts && client.contacts.length > 0 && (
+            <div className="stack">
+              <h4>Key contacts</h4>
+              <ul className="stack">
+                {client.contacts.map((contact) => (
+                  <li key={contact.id}>
+                    <strong>
+                      {contact.first_name} {contact.last_name}
+                    </strong>
+                    {contact.title && <div className="text-muted">{contact.title}</div>}
+                    <div>{contact.email}</div>
+                    {contact.phone && <div>{contact.phone}</div>}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </div>
+
+        <div className="card">
+          <h3>Financial pulse</h3>
+          <div className="metric">
+            <span>Total outstanding</span>
+            <strong>{formatCurrency(financials.total_outstanding)}</strong>
+          </div>
+          <div className="metric">
+            <span>Next payment due</span>
+            <strong>
+              {financials.next_invoice_due
+                ? `${formatCurrency(financials.next_invoice_due.balance_due, financials.next_invoice_due.currency)} · ${formatDate(
+                    financials.next_invoice_due.due_date
+                  )}`
+                : "No pending invoices"}
+            </strong>
+          </div>
+          {financials.recent_payments.length > 0 && (
+            <div className="stack">
+              <h4>Recent payments</h4>
+              <ul className="stack">
+                {financials.recent_payments.slice(0, 3).map((payment) => (
+                  <li key={payment.id}>
+                    {formatCurrency(payment.amount)} received on {formatDate(payment.received_at)} via {payment.method}
+                    {payment.invoice_number && <span className="text-muted"> · Invoice {payment.invoice_number}</span>}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </div>
+
+        <div className="card">
+          <h3>Support status</h3>
+          <div className="metric">
+            <span>Open tickets</span>
+            <strong>{support.open_tickets.length}</strong>
+          </div>
+          <div className="metric">
+            <span>Last activity</span>
+            <strong>{support.last_ticket_update ? formatDate(support.last_ticket_update) : "No recent updates"}</strong>
+          </div>
+          {support.open_tickets.length > 0 && (
+            <ul className="stack">
+              {support.open_tickets.map((ticket) => (
+                <li key={ticket.id}>
+                  <strong>{ticket.subject}</strong>
+                  <div className="text-muted">
+                    {ticket.status.replace("_", " ")} · Priority {ticket.priority}
+                  </div>
+                  {ticket.sla_due && <div>Target SLA: {formatDate(ticket.sla_due)}</div>}
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </div>
+
+      <section className="detail-section">
+        <h2>Projects in progress</h2>
+        <p className="text-muted">Track delivery milestones, upcoming tasks, and leadership across every engagement.</p>
+        <div className="table-scroll">
+          <table className="table">
+            <thead>
+              <tr>
+                <th>Project</th>
+                <th>Type</th>
+                <th>Status</th>
+                <th>Next milestone</th>
+                <th>Next task</th>
+                <th>Budget</th>
+              </tr>
+            </thead>
+            <tbody>
+              {projects.length === 0 && (
+                <tr>
+                  <td colSpan={6} className="text-muted">
+                    No active projects yet.
+                  </td>
+                </tr>
+              )}
+              {projects.map((project) => (
+                <tr key={project.id}>
+                  <td>
+                    <div className="stack">
+                      <strong>{project.name}</strong>
+                      <span className="text-muted">Code {project.code}</span>
+                    </div>
+                  </td>
+                  <td style={{ textTransform: "capitalize" }}>{project.project_type}</td>
+                  <td style={{ textTransform: "capitalize" }}>{project.status.replace("_", " ")}</td>
+                  <td>{project.next_milestone ? `${project.next_milestone.title} · ${formatDate(project.next_milestone.due_date)}` : "-"}</td>
+                  <td>{project.next_task ? `${project.next_task.name} · ${formatDate(project.next_task.due_date)}` : "-"}</td>
+                  <td>
+                    {typeof project.budget === "number"
+                      ? formatCurrency(project.budget, project.currency)
+                      : "-"}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section className="detail-section">
+        <h2>Outstanding invoices</h2>
+        <p className="text-muted">Monitor cash flow risk and upcoming payment commitments.</p>
+        <div className="table-scroll">
+          <table className="table">
+            <thead>
+              <tr>
+                <th>Invoice</th>
+                <th>Project</th>
+                <th>Status</th>
+                <th>Due date</th>
+                <th>Balance due</th>
+              </tr>
+            </thead>
+            <tbody>
+              {financials.outstanding_invoices.length === 0 && (
+                <tr>
+                  <td colSpan={5} className="text-muted">
+                    No outstanding balances.
+                  </td>
+                </tr>
+              )}
+              {financials.outstanding_invoices.map((invoice) => (
+                <tr key={invoice.id}>
+                  <td>{invoice.number}</td>
+                  <td>{invoice.project_name ?? "-"}</td>
+                  <td style={{ textTransform: "capitalize" }}>{invoice.status.replace("_", " ")}</td>
+                  <td>{formatDate(invoice.due_date)}</td>
+                  <td>{formatCurrency(invoice.balance_due, invoice.currency)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/frontend/app/clients/page.tsx
+++ b/frontend/app/clients/page.tsx
@@ -1,22 +1,10 @@
 export const dynamic = "force-dynamic";
 
 import { api, Client } from "../../lib/api";
+import { ClientsTable } from "./ClientsTable";
 
 async function getClients(): Promise<Client[]> {
   return api.clients();
-}
-
-function labelForSegment(segment: string): string {
-  switch (segment) {
-    case "retainer":
-      return "badge success";
-    case "project":
-      return "badge";
-    case "vip":
-      return "badge warning";
-    default:
-      return "badge";
-  }
 }
 
 export default async function ClientsPage(): Promise<JSX.Element> {
@@ -29,32 +17,7 @@ export default async function ClientsPage(): Promise<JSX.Element> {
         Every account centralizes contacts, documents, and preferred communication channels to power proactive service across the
         two brands.
       </p>
-      <table className="table">
-        <thead>
-          <tr>
-            <th>Organization</th>
-            <th>Industry</th>
-            <th>Segment</th>
-            <th>Billing Email</th>
-            <th>Timezone</th>
-          </tr>
-        </thead>
-        <tbody>
-          {clients.map((client) => (
-            <tr key={client.id}>
-              <td>{client.organization_name}</td>
-              <td style={{ textTransform: "capitalize" }}>{client.industry}</td>
-              <td>
-                <span className={labelForSegment(client.segment)} style={{ textTransform: "uppercase", letterSpacing: "0.08em" }}>
-                  {client.segment}
-                </span>
-              </td>
-              <td>{client.billing_email}</td>
-              <td>{client.timezone}</td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
+      <ClientsTable clients={clients} />
     </div>
   );
 }

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -115,3 +115,240 @@ main {
   font-weight: 600;
   margin-bottom: 0.5rem;
 }
+
+.table-scroll {
+  overflow-x: auto;
+}
+
+.clients-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.6rem 1.25rem;
+  border-radius: 9999px;
+  border: 1px solid transparent;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.15s ease;
+}
+
+.button.primary {
+  background: linear-gradient(135deg, #38bdf8, #8b5cf6);
+  color: #0f172a;
+  box-shadow: 0 12px 20px rgba(56, 189, 248, 0.25);
+}
+
+.button.primary:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 18px 28px rgba(56, 189, 248, 0.35);
+}
+
+.button.ghost {
+  background: transparent;
+  border-color: rgba(148, 163, 184, 0.4);
+  color: #e2e8f0;
+}
+
+.button.ghost:hover {
+  border-color: rgba(148, 163, 184, 0.7);
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.form-section {
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 1rem;
+  padding: 1.25rem;
+}
+
+.form-section legend {
+  padding: 0 0.5rem;
+  font-weight: 600;
+  color: #cbd5f5;
+}
+
+.form-grid {
+  display: grid;
+  gap: 1rem;
+}
+
+@media (min-width: 768px) {
+  .form-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.form-grid label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-size: 0.95rem;
+}
+
+.form-grid input,
+.form-grid select,
+.form-grid textarea {
+  padding: 0.65rem 0.75rem;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(15, 23, 42, 0.7);
+  color: #f8fafc;
+}
+
+.form-grid input:focus,
+.form-grid select:focus,
+.form-grid textarea:focus {
+  outline: none;
+  border-color: rgba(56, 189, 248, 0.75);
+  box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.2);
+}
+
+.form-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 1rem;
+}
+
+.form-feedback {
+  font-size: 0.95rem;
+}
+
+.form-feedback.error {
+  color: #f87171;
+}
+
+.form-feedback.success {
+  color: #4ade80;
+}
+
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.78);
+  backdrop-filter: blur(6px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+  z-index: 50;
+}
+
+.modal {
+  width: min(720px, 100%);
+  background: rgba(15, 23, 42, 0.95);
+  border-radius: 1.5rem;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  box-shadow: 0 28px 60px rgba(15, 23, 42, 0.45);
+  padding: 1.75rem;
+  max-height: calc(100vh - 4rem);
+  overflow-y: auto;
+}
+
+.modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+.clickable-row {
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.clickable-row:hover {
+  background: rgba(148, 163, 184, 0.08);
+}
+
+.back-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+  color: #38bdf8;
+  text-decoration: none;
+}
+
+.back-link:hover {
+  color: #0ea5e9;
+}
+
+.client-detail {
+  display: flex;
+  flex-direction: column;
+  gap: 2.5rem;
+}
+
+.detail-cards {
+  gap: 1.5rem;
+}
+
+.definition-list {
+  display: grid;
+  gap: 0.75rem;
+  margin: 0 0 1.5rem;
+}
+
+.definition-list div {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+}
+
+.definition-list dt {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #94a3b8;
+}
+
+.definition-list dd {
+  margin: 0;
+  font-weight: 600;
+}
+
+.stack {
+  display: grid;
+  gap: 0.5rem;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.metric {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  padding: 0.75rem 0;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.metric span {
+  color: #94a3b8;
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+}
+
+.metric strong {
+  font-size: 1.1rem;
+}
+
+.detail-section {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -24,6 +24,13 @@ export const api = {
   dashboard: () => request<DashboardSnapshot>("/dashboard"),
   projects: () => request<Project[]>("/projects"),
   clients: () => request<Client[]>("/clients"),
+  client: (clientId: string) => request<Client>(`/clients/${clientId}`),
+  clientDashboard: (clientId: string) => request<ClientDashboard>(`/clients/${clientId}/dashboard`),
+  createClient: (payload: ClientCreateRequest) =>
+    request<ClientWithProjects>("/clients", {
+      method: "POST",
+      body: JSON.stringify(payload)
+    }),
   invoices: () => request<Invoice[]>("/financials/invoices"),
   financialOverview: () => request<MacroFinancials>("/financials/overview"),
   projectFinancials: () => request<ProjectFinancials[]>("/financials/projects"),
@@ -108,14 +115,147 @@ export interface Task {
   logged_hours: number;
 }
 
-export interface Client {
+export type Industry = "hospitality" | "creative" | "technology" | "other";
+
+export type ClientSegment = "retainer" | "project" | "vip" | "prospect";
+
+export type InteractionChannel = "email" | "portal" | "social" | "phone";
+
+export interface TimestampedEntity {
+  id: string;
+  created_at: string;
+  updated_at: string;
+  deleted_at?: string | null;
+}
+
+export interface ContactInput {
+  first_name: string;
+  last_name: string;
+  email: string;
+  phone?: string | null;
+  title?: string | null;
+}
+
+export interface Contact extends TimestampedEntity, ContactInput {}
+
+export interface Interaction extends TimestampedEntity {
+  channel: InteractionChannel;
+  subject: string;
+  summary: string;
+  occurred_at: string;
+  owner_id?: string | null;
+}
+
+export interface ClientDocument extends TimestampedEntity {
+  name: string;
+  url: string;
+  version: string;
+  uploaded_by: string;
+  signed: boolean;
+}
+
+export interface Client extends TimestampedEntity {
   id: string;
   organization_name: string;
-  industry: string;
-  segment: string;
+  industry: Industry;
+  segment: ClientSegment;
   billing_email: string;
-  preferred_channel: string;
+  preferred_channel: InteractionChannel;
   timezone: string;
+  contacts?: Contact[];
+  interactions?: Interaction[];
+  documents?: ClientDocument[];
+}
+
+export interface ClientProjectDigest {
+  id: string;
+  code: string;
+  name: string;
+  project_type: string;
+  status: string;
+  start_date: string;
+  end_date?: string | null;
+  manager_id: string;
+  budget?: number | null;
+  currency: string;
+  late_tasks: Task[];
+  next_task?: Task | null;
+  next_milestone?: Milestone | null;
+}
+
+export interface ClientInvoiceDigest {
+  id: string;
+  number: string;
+  status: string;
+  due_date: string;
+  total: number;
+  balance_due: number;
+  currency: string;
+  project_id?: string | null;
+  project_name?: string | null;
+}
+
+export interface ClientPaymentDigest {
+  id: string;
+  invoice_id: string;
+  invoice_number?: string | null;
+  amount: number;
+  received_at: string;
+  method: string;
+}
+
+export interface ClientFinancialSnapshot {
+  outstanding_invoices: ClientInvoiceDigest[];
+  next_invoice_due?: ClientInvoiceDigest | null;
+  recent_payments: ClientPaymentDigest[];
+  total_outstanding: number;
+}
+
+export interface ClientTicketDigest {
+  id: string;
+  subject: string;
+  status: string;
+  priority: string;
+  sla_due?: string | null;
+  last_activity_at?: string | null;
+}
+
+export interface ClientSupportSnapshot {
+  open_tickets: ClientTicketDigest[];
+  last_ticket_update?: string | null;
+}
+
+export interface ClientDashboard {
+  client: Client;
+  projects: ClientProjectDigest[];
+  financials: ClientFinancialSnapshot;
+  support: ClientSupportSnapshot;
+}
+
+export interface ProjectSetup {
+  name: string;
+  project_type: string;
+  start_date: string;
+  manager_id: string;
+  budget: number;
+  currency: string;
+  start_after?: string | null;
+}
+
+export interface ClientCreateRequest {
+  organization_name: string;
+  industry: Industry;
+  segment: ClientSegment;
+  billing_email: string;
+  preferred_channel: InteractionChannel;
+  timezone: string;
+  contacts: ContactInput[];
+  projects: ProjectSetup[];
+}
+
+export interface ClientWithProjects {
+  client: Client;
+  projects: Project[];
 }
 
 export interface Invoice {


### PR DESCRIPTION
## Summary
- add an interactive clients table with a modal workflow to create new clients and navigate to detail views
- add a dedicated client intelligence page that surfaces project, financial, and support insights
- extend shared API typings and styles to support client creation and detail presentations

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d3561137448333a0a6c1dbe0c6fa19