### PR TITLE
feat: extend backend editing and status insights

### DIFF
--- a/backend/app/api/routes/clients.py
+++ b/backend/app/api/routes/clients.py
@@ -6,7 +6,9 @@ from ...schemas.clients import (
     Client,
     ClientCreateRequest,
     ClientDashboard,
+    ClientEngagement,
     ClientSummary,
+    ClientUpdateRequest,
     ClientWithProjects,
 )
 from ...services.data import store
@@ -19,17 +21,14 @@ def list_clients() -> List[Client]:
     return list(store.clients.values())
 
 
-@router.get("/{client_id}", response_model=Client)
-def get_client(client_id: str) -> Client:
-    client = store.clients.get(client_id)
-    if not client:
-        raise HTTPException(status_code=404, detail="Client not found")
-    return client
-
-
 @router.get("/summary", response_model=ClientSummary)
 def client_summary() -> ClientSummary:
     return store.client_summary()
+
+
+@router.get("/engagements", response_model=List[ClientEngagement])
+def client_engagements() -> List[ClientEngagement]:
+    return store.client_engagements()
 
 
 @router.post("", response_model=ClientWithProjects, status_code=status.HTTP_201_CREATED)
@@ -38,6 +37,23 @@ def create_client(payload: ClientCreateRequest) -> ClientWithProjects:
         return store.create_client_with_projects(payload)
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@router.get("/{client_id}", response_model=Client)
+def get_client(client_id: str) -> Client:
+    client = store.clients.get(client_id)
+    if not client:
+        raise HTTPException(status_code=404, detail="Client not found")
+    return client
+
+
+@router.patch("/{client_id}", response_model=Client)
+def update_client(client_id: str, payload: ClientUpdateRequest) -> Client:
+    try:
+        return store.update_client(client_id, payload)
+    except ValueError as exc:
+        status_code = status.HTTP_404_NOT_FOUND if str(exc) == "Client not found" else status.HTTP_400_BAD_REQUEST
+        raise HTTPException(status_code=status_code, detail=str(exc)) from exc
 
 
 @router.get("/{client_id}/dashboard", response_model=ClientDashboard)

--- a/backend/app/api/routes/projects.py
+++ b/backend/app/api/routes/projects.py
@@ -2,7 +2,7 @@ from typing import List
 
 from fastapi import APIRouter, HTTPException
 
-from ...schemas.projects import Project, ProjectSummary, ProjectUpdateRequest
+from ...schemas.projects import Project, ProjectProgress, ProjectSummary, ProjectUpdateRequest
 from ...services.data import store
 
 router = APIRouter(prefix="/projects", tags=["projects"])
@@ -11,6 +11,16 @@ router = APIRouter(prefix="/projects", tags=["projects"])
 @router.get("", response_model=List[Project])
 def list_projects() -> List[Project]:
     return list(store.projects.values())
+
+
+@router.get("/summary", response_model=ProjectSummary)
+def project_summary() -> ProjectSummary:
+    return store.project_summary()
+
+
+@router.get("/portfolio", response_model=List[ProjectProgress])
+def project_portfolio() -> List[ProjectProgress]:
+    return store.project_portfolio()
 
 
 @router.get("/{project_id}", response_model=Project)
@@ -27,8 +37,3 @@ def update_project(project_id: str, payload: ProjectUpdateRequest) -> Project:
         return store.update_project(project_id, payload)
     except ValueError as exc:  # pragma: no cover - defensive
         raise HTTPException(status_code=404, detail=str(exc)) from exc
-
-
-@router.get("/summary", response_model=ProjectSummary)
-def project_summary() -> ProjectSummary:
-    return store.project_summary()

--- a/backend/app/schemas/clients.py
+++ b/backend/app/schemas/clients.py
@@ -1,14 +1,13 @@
+from datetime import datetime
 from enum import Enum
 from typing import List, Optional
-from datetime import datetime
 
 from pydantic import BaseModel, EmailStr, Field
-
-from .common import IdentifiedModel
 from pydantic.class_validators import root_validator
 
-from .projects import Milestone, Project, ProjectStatus, Task
+from .common import IdentifiedModel
 from .financials import Currency, InvoiceStatus
+from .projects import Milestone, Project, ProjectStatus, Task
 from .support import TicketStatus
 
 
@@ -111,6 +110,45 @@ class ClientCreateRequest(BaseModel):
         return values
 
 
+class ContactUpdate(BaseModel):
+    id: Optional[str] = None
+    first_name: Optional[str] = None
+    last_name: Optional[str] = None
+    email: Optional[EmailStr] = None
+    phone: Optional[str] = None
+    title: Optional[str] = None
+
+
+class InteractionUpdate(BaseModel):
+    id: Optional[str] = None
+    channel: Optional[InteractionChannel] = None
+    subject: Optional[str] = None
+    summary: Optional[str] = None
+    occurred_at: Optional[datetime] = None
+    owner_id: Optional[str] = None
+
+
+class DocumentUpdate(BaseModel):
+    id: Optional[str] = None
+    name: Optional[str] = None
+    url: Optional[str] = None
+    version: Optional[str] = None
+    uploaded_by: Optional[str] = None
+    signed: Optional[bool] = None
+
+
+class ClientUpdateRequest(BaseModel):
+    organization_name: Optional[str] = None
+    industry: Optional[Industry] = None
+    segment: Optional[ClientSegment] = None
+    billing_email: Optional[EmailStr] = None
+    preferred_channel: Optional[InteractionChannel] = None
+    timezone: Optional[str] = None
+    contacts: Optional[List[ContactUpdate]] = None
+    interactions: Optional[List[InteractionUpdate]] = None
+    documents: Optional[List[DocumentUpdate]] = None
+
+
 class ClientWithProjects(BaseModel):
     client: Client
     projects: List[Project]
@@ -179,3 +217,15 @@ class ClientDashboard(BaseModel):
     projects: List[ClientProjectDigest] = Field(default_factory=list)
     financials: ClientFinancialSnapshot
     support: ClientSupportSnapshot
+
+
+class ClientEngagement(BaseModel):
+    client_id: str
+    organization_name: str
+    segment: ClientSegment
+    active_projects: int
+    late_projects: int
+    outstanding_balance: float
+    next_milestone: Optional[Milestone] = None
+    last_interaction_at: Optional[datetime] = None
+    health: str

--- a/backend/app/schemas/projects.py
+++ b/backend/app/schemas/projects.py
@@ -119,3 +119,26 @@ class ProjectUpdateRequest(BaseModel):
     template_id: Optional[str] = None
     tasks: Optional[List[TaskUpdate]] = None
     milestones: Optional[List[MilestoneUpdate]] = None
+
+
+class ProjectHealth(str, Enum):
+    ON_TRACK = "on_track"
+    AT_RISK = "at_risk"
+    BLOCKED = "blocked"
+    COMPLETED = "completed"
+
+
+class ProjectProgress(BaseModel):
+    project_id: str
+    code: str
+    name: str
+    status: ProjectStatus
+    client_id: str
+    client_name: Optional[str] = None
+    total_tasks: int
+    completed_tasks: int
+    late_tasks: int
+    progress: float
+    next_milestone: Optional[Milestone] = None
+    health: ProjectHealth
+    updated_at: datetime


### PR DESCRIPTION
## Summary
- add client update models, engagement snapshot schema, and corresponding PATCH & engagement routes to support end-to-end client editing and visibility
- expose project portfolio progress plus portfolio health calculations in the in-memory store and API
- expand automated coverage for client updates, engagement overviews, and project progress calculations

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d4046bc8748333923a8e6f2af00f31