### PR TITLE
Implement automation digest UI and PH tax automation upgrades

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ The repository currently contains only a placeholder README, so the project will
 - Expense capture, receipt OCR, project profitability, revenue forecasting.
 - Sync with accounting systems (QuickBooks/Xero via webhooks & polling).
 - Payment gateway integration (Stripe, PayPal) with PCI compliance delegation.
+- **Quarterly tax maintenance**: update the TRAIN-law bracket table (`PH_TAX_BRACKETS`) and percentage/VAT logic in
+  `backend/app/services/data.py` every quarter, then trigger a fresh automation digest snapshot to compare against archived
+  filings.
 
 ### 6. HR & Resource Management
 - Employee/contractor profiles, skills matrix, certifications, onboarding flows.

--- a/backend/app/api/routes/automation.py
+++ b/backend/app/api/routes/automation.py
@@ -1,3 +1,5 @@
+from typing import List
+
 from fastapi import APIRouter
 
 from ...schemas.automation import AutomationDigest
@@ -13,5 +15,14 @@ def automation_digest() -> AutomationDigest:
     """Return suggested automation tasks for the current dataset."""
 
     engine = AutomationEngine(store)
-    return engine.generate_digest()
+    digest = engine.generate_digest()
+    store.archive_automation_digest(digest)
+    return digest
+
+
+@router.get("/digest/history", response_model=List[AutomationDigest])
+def automation_digest_history() -> List[AutomationDigest]:
+    """Return archived automation digests for audit and trend analysis."""
+
+    return store.automation_digest_history()
 

--- a/backend/app/api/routes/financials.py
+++ b/backend/app/api/routes/financials.py
@@ -12,6 +12,7 @@ from ...schemas.financials import (
     ProjectFinancials,
     TaxComputationRequest,
     TaxComputationResponse,
+    TaxProfile,
 )
 from ...services.data import store
 
@@ -54,6 +55,11 @@ def project_financials() -> List[ProjectFinancials]:
 @router.get("/overview", response_model=MacroFinancials)
 def macro_financials() -> MacroFinancials:
     return store.macro_financials()
+
+
+@router.get("/tax/profile", response_model=TaxProfile)
+def tax_profile() -> TaxProfile:
+    return store.tax_profile()
 
 
 @router.post("/tax/compute", response_model=TaxComputationResponse)

--- a/backend/app/core/background.py
+++ b/backend/app/core/background.py
@@ -1,0 +1,47 @@
+"""Background jobs to keep automation surfaced without manual polling."""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import suppress
+from datetime import timedelta
+from typing import Optional
+
+from ..services.automation import AutomationEngine
+from ..services.data import InMemoryStore, store
+
+
+class AutomationDigestScheduler:
+    """Periodically capture automation digests and broadcast summaries."""
+
+    def __init__(self, data_store: InMemoryStore, *, interval: timedelta = timedelta(hours=24)) -> None:
+        self._store = data_store
+        self._interval = interval
+        self._task: Optional[asyncio.Task[None]] = None
+        self._running = False
+
+    async def start(self) -> None:
+        if self._task is not None:
+            return
+        self._running = True
+        self._task = asyncio.create_task(self._runner())
+
+    async def stop(self) -> None:
+        if self._task is None:
+            return
+        self._running = False
+        self._task.cancel()
+        with suppress(asyncio.CancelledError):
+            await self._task
+        self._task = None
+
+    async def _runner(self) -> None:
+        while self._running:
+            engine = AutomationEngine(self._store)
+            digest = engine.generate_digest()
+            self._store.archive_automation_digest(digest)
+            self._store.record_automation_broadcast(digest)
+            await asyncio.sleep(self._interval.total_seconds())
+
+
+automation_scheduler = AutomationDigestScheduler(store)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,6 +1,7 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
+from .core.background import automation_scheduler
 from .core.config import get_settings
 from .api.routes import (
     auth,
@@ -49,3 +50,13 @@ def root() -> dict:
 @app.get("/health")
 def health() -> dict:
     return {"status": "ok"}
+
+
+@app.on_event("startup")
+async def startup_tasks() -> None:
+    await automation_scheduler.start()
+
+
+@app.on_event("shutdown")
+async def shutdown_tasks() -> None:
+    await automation_scheduler.stop()

--- a/backend/app/schemas/automation.py
+++ b/backend/app/schemas/automation.py
@@ -40,6 +40,8 @@ class AutomationTask(IdentifiedModel):
     suggested_assignee: Optional[str] = None
     details: Optional[str] = None
     related_ids: Dict[str, str] = Field(default_factory=dict)
+    action_label: Optional[str] = None
+    action_url: Optional[str] = None
 
 
 class AutomationDigest(IdentifiedModel):

--- a/backend/app/schemas/financials.py
+++ b/backend/app/schemas/financials.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from enum import Enum
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 from pydantic import BaseModel, Field
 
@@ -115,6 +115,19 @@ class TaxComputationResponse(BaseModel):
     total_tax: float
     effective_tax_rate: float
     deduction_opportunities: List[DeductionOpportunity] = Field(default_factory=list)
+
+
+class TaxProfile(BaseModel):
+    incomes: List[TaxEntry] = Field(default_factory=list)
+    cost_of_sales: List[TaxEntry] = Field(default_factory=list)
+    operating_expenses: List[TaxEntry] = Field(default_factory=list)
+    other_deductions: List[TaxEntry] = Field(default_factory=list)
+    apply_percentage_tax: bool = True
+    percentage_tax_rate: float = 3.0
+    vat_registered: bool = False
+    last_updated: datetime
+    source_summary: Dict[str, int] = Field(default_factory=dict)
+    computed: TaxComputationResponse
 
 
 class PricingSuggestion(BaseModel):

--- a/backend/app/services/automation.py
+++ b/backend/app/services/automation.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime, time, timedelta
 from typing import Iterable, List
+from urllib.parse import quote_plus
 
 from ..schemas.automation import (
     AutomationCategory,
@@ -12,11 +13,11 @@ from ..schemas.automation import (
     AutomationPriority,
     AutomationTask,
 )
-from ..schemas.clients import ClientEngagement
+from ..schemas.clients import Client, ClientEngagement
 from ..schemas.financials import Invoice, InvoiceStatus
 from ..schemas.hr import Employee, TimeOffStatus
 from ..schemas.marketing import Campaign, ContentItem, ContentStatus
-from ..schemas.monitoring import Site
+from ..schemas.monitoring import Check, Site
 from ..schemas.projects import ProjectHealth, ProjectStatus
 from ..schemas.support import TicketStatus
 from .data import InMemoryStore
@@ -35,6 +36,7 @@ class _Context:
     """Lightweight cache of frequently accessed store entities."""
 
     clients: dict[str, ClientEngagement]
+    client_records: dict[str, Client]
     employees: dict[str, Employee]
     campaigns: dict[str, Campaign]
     sites: dict[str, Site]
@@ -58,6 +60,7 @@ class AutomationEngine:
 
         context = _Context(
             clients={eng.client_id: eng for eng in self._store.client_engagements()},
+            client_records=self._store.clients,
             employees=self._store.employees,
             campaigns=self._store.campaigns,
             sites=self._store.sites,
@@ -65,11 +68,13 @@ class AutomationEngine:
 
         tasks.extend(self._client_tasks(context.clients.values()))
         tasks.extend(self._project_tasks())
-        tasks.extend(self._financial_tasks())
+        tasks.extend(self._financial_tasks(context))
         tasks.extend(self._support_tasks())
         tasks.extend(self._marketing_tasks(context))
         tasks.extend(self._monitoring_tasks(context))
         tasks.extend(self._hr_tasks(context))
+        tasks.extend(self._recurring_tasks(context))
+        tasks.extend(self._tax_tasks())
 
         tasks.sort(key=self._sort_key)
         return AutomationDigest(generated_at=self.now, tasks=tasks)
@@ -115,6 +120,8 @@ class AutomationEngine:
                     due_at=due_at,
                     details="; ".join(details) if details else None,
                     related_ids={"client_id": engagement.client_id},
+                    action_label="Open client dashboard",
+                    action_url=f"/clients/{engagement.client_id}",
                 )
             )
         return tasks
@@ -158,11 +165,13 @@ class AutomationEngine:
                         "project_id": progress.project_id,
                         "client_id": progress.client_id,
                     },
+                    action_label="Review project",
+                    action_url=f"/projects/{progress.project_id}",
                 )
             )
         return tasks
 
-    def _financial_tasks(self) -> List[AutomationTask]:
+    def _financial_tasks(self, context: _Context) -> List[AutomationTask]:
         tasks: List[AutomationTask] = []
         for invoice in self._store.invoices.values():
             if invoice.status not in {InvoiceStatus.SENT, InvoiceStatus.OVERDUE}:
@@ -180,6 +189,17 @@ class AutomationEngine:
                 priority = AutomationPriority.HIGH if days_until_due <= 14 else AutomationPriority.MEDIUM
                 due_at = invoice.due_date if days_until_due <= 21 else None
 
+            client = context.client_records.get(invoice.client_id)
+            if client:
+                subject = quote_plus(f"Invoice {invoice.number} payment reminder")
+                body = quote_plus(
+                    "Hi team, just a friendly reminder that invoice "
+                    f"{invoice.number} is due on {invoice.due_date.date()}. Please let us know if you need anything."
+                )
+                action_url = f"mailto:{client.billing_email}?subject={subject}&body={body}"
+            else:
+                action_url = "/financials"
+
             tasks.append(
                 AutomationTask(
                     category=AutomationCategory.FINANCE,
@@ -188,6 +208,8 @@ class AutomationEngine:
                     due_at=due_at,
                     details=f"Balance due ${balance:,.2f} by {invoice.due_date.date()}",
                     related_ids={"invoice_id": invoice.id, "client_id": invoice.client_id},
+                    action_label="Send reminder",
+                    action_url=action_url,
                 )
             )
         return tasks
@@ -217,6 +239,8 @@ class AutomationEngine:
                     details=f"Status: {ticket.status.value}, Priority: {ticket.priority}",
                     related_ids={"ticket_id": ticket.id, "client_id": ticket.client_id},
                     suggested_assignee=ticket.assignee_id,
+                    action_label="Open ticket",
+                    action_url=f"/support?ticketId={ticket.id}",
                 )
             )
         return tasks
@@ -250,6 +274,8 @@ class AutomationEngine:
                     details="; ".join(details),
                     related_ids=related_ids,
                     suggested_assignee=campaign.owner_id if campaign else None,
+                    action_label="Prep content",
+                    action_url=f"/marketing?contentId={content.id}",
                 )
             )
         return tasks
@@ -279,6 +305,8 @@ class AutomationEngine:
                     due_at=alert.triggered_at + timedelta(hours=6),
                     details=alert.message,
                     related_ids={"alert_id": alert.id, "site_id": alert.site_id},
+                    action_label="Open incident",
+                    action_url=f"/monitoring?alertId={alert.id}",
                 )
             )
         return tasks
@@ -304,6 +332,118 @@ class AutomationEngine:
                     details=f"Requested {request.start_date} to {request.end_date}",
                     related_ids={"time_off_request_id": request.id, "employee_id": request.employee_id},
                     suggested_assignee=assignee,
+                    action_label="Approve leave",
+                    action_url=f"/hr?requestId={request.id}",
+                )
+            )
+        return tasks
+
+    def _recurring_tasks(self, context: _Context) -> List[AutomationTask]:
+        tasks: List[AutomationTask] = []
+        renewal_window = timedelta(days=45)
+        for client in self._store.clients.values():
+            for document in client.documents:
+                if not document.signed:
+                    continue
+                if "retainer" not in document.name.lower() and "contract" not in document.name.lower():
+                    continue
+
+                renewal_date = document.created_at + timedelta(days=365)
+                if renewal_date < self.now - timedelta(days=5):
+                    continue
+                if renewal_date - self.now > renewal_window:
+                    continue
+
+                if renewal_date <= self.now:
+                    priority = AutomationPriority.CRITICAL
+                    due_at = self.now
+                else:
+                    priority = AutomationPriority.HIGH
+                    due_at = renewal_date - timedelta(days=15)
+
+                tasks.append(
+                    AutomationTask(
+                        category=AutomationCategory.CLIENT,
+                        summary=f"Prep contract renewal for {client.organization_name}",
+                        priority=priority,
+                        due_at=due_at,
+                        details=f"Retainer version {document.version} expires {renewal_date.date()}",
+                        related_ids={"client_id": client.id, "document_id": document.id},
+                        action_label="Review agreement",
+                        action_url=document.url,
+                    )
+                )
+
+        for content in self._store.content_items.values():
+            if content.status != ContentStatus.DRAFT:
+                continue
+            age = self.now - content.created_at
+            if age < timedelta(days=3):
+                continue
+
+            campaign = context.campaigns.get(content.campaign_id) if content.campaign_id else None
+            due_at = content.scheduled_for - timedelta(days=1) if content.scheduled_for else self.now + timedelta(days=1)
+            details = [f"Platform: {content.platform}" if content.platform else "Draft content awaiting approval"]
+            if campaign:
+                details.append(f"Campaign: {campaign.name}")
+
+            tasks.append(
+                AutomationTask(
+                    category=AutomationCategory.MARKETING,
+                    summary=f"Approve content '{content.title}'",
+                    priority=AutomationPriority.HIGH,
+                    due_at=due_at,
+                    details="; ".join(details),
+                    related_ids={"content_id": content.id},
+                    suggested_assignee=campaign.owner_id if campaign else None,
+                    action_label="Approve content",
+                    action_url=f"/marketing?contentId={content.id}",
+                )
+            )
+
+        for check in self._store.checks.values():
+            check_type = check.type.lower()
+            if "soc" not in check_type and "compliance" not in check_type:
+                continue
+
+            time_since_audit = self.now - check.last_run
+            if time_since_audit < timedelta(days=30):
+                continue
+
+            due_at_candidate = check.last_run + timedelta(days=35)
+            due_at = due_at_candidate if due_at_candidate > self.now else self.now + timedelta(days=1)
+            site = context.sites.get(check.site_id)
+            site_label = site.label if site else "Infrastructure"
+
+            tasks.append(
+                AutomationTask(
+                    category=AutomationCategory.MONITORING,
+                    summary=f"Run SOC control review for {site_label}",
+                    priority=AutomationPriority.HIGH,
+                    due_at=due_at,
+                    details=f"Last audit ran {time_since_audit.days} days ago",
+                    related_ids={"check_id": check.id, "site_id": check.site_id},
+                    action_label="Review controls",
+                    action_url=f"/monitoring?checkId={check.id}",
+                )
+            )
+
+        return tasks
+
+    def _tax_tasks(self) -> List[AutomationTask]:
+        tasks: List[AutomationTask] = []
+        profile = self._store.tax_profile()
+        for tip in profile.computed.deduction_opportunities:
+            tasks.append(
+                AutomationTask(
+                    category=AutomationCategory.FINANCE,
+                    summary=f"Document {tip.category.upper()} deductions",
+                    priority=AutomationPriority.MEDIUM,
+                    due_at=self.now + timedelta(days=7),
+                    details=tip.message,
+                    related_ids={"tax_profile": "philippines"},
+                    action_label="Open tax planner",
+                    action_url="/financials/tax-calculator",
                 )
             )
         return tasks

--- a/frontend/app/automation/page.tsx
+++ b/frontend/app/automation/page.tsx
@@ -1,0 +1,67 @@
+export const dynamic = "force-dynamic";
+
+import { api, AutomationDigest } from "../../lib/api";
+
+function formatDate(value: string): string {
+  return new Date(value).toLocaleString();
+}
+
+async function getAutomationHistory(): Promise<AutomationDigest[]> {
+  return api.automationHistory();
+}
+
+export default async function AutomationHistoryPage(): Promise<JSX.Element> {
+  const history = await getAutomationHistory();
+
+  return (
+    <div>
+      <h2 className="section-title">Automation archive</h2>
+      <p className="text-muted" style={{ maxWidth: "720px" }}>
+        Daily snapshots capture the automation engine output for audit trails and change management. Use the archive to see
+        how playbooks evolve over time and which teams are absorbing actions.
+      </p>
+      <table className="table" style={{ marginTop: "1.5rem" }}>
+        <thead>
+          <tr>
+            <th>Generated</th>
+            <th>Total tasks</th>
+            <th>Top priority</th>
+            <th>Highlights</th>
+          </tr>
+        </thead>
+        <tbody>
+          {history.length === 0 ? (
+            <tr>
+              <td colSpan={4} style={{ textAlign: "center", color: "#94a3b8" }}>
+                No automation history recorded yet.
+              </td>
+            </tr>
+          ) : (
+            history
+              .slice()
+              .reverse()
+              .map((digest) => {
+                const priorities = digest.tasks.map((task) => task.priority);
+                const topPriority = priorities.includes("critical")
+                  ? "critical"
+                  : priorities.includes("high")
+                  ? "high"
+                  : priorities.includes("medium")
+                  ? "medium"
+                  : "low";
+                const highlights = digest.tasks.slice(0, 3).map((task) => task.summary);
+                return (
+                  <tr key={digest.id}>
+                    <td>{formatDate(digest.generated_at)}</td>
+                    <td>{digest.tasks.length}</td>
+                    <td style={{ textTransform: "capitalize" }}>{topPriority}</td>
+                    <td>{highlights.join(" • ")}</td>
+                  </tr>
+                );
+              })
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/frontend/app/components/AutomationPanel.tsx
+++ b/frontend/app/components/AutomationPanel.tsx
@@ -1,0 +1,138 @@
+import Link from "next/link";
+
+import { api, AutomationDigest, AutomationTask } from "../../lib/api";
+
+function priorityTone(priority: AutomationTask["priority"]): string {
+  switch (priority) {
+    case "critical":
+      return "badge danger";
+    case "high":
+      return "badge warning";
+    case "medium":
+      return "badge";
+    default:
+      return "badge muted";
+  }
+}
+
+function formatDueDate(task: AutomationTask): string | null {
+  if (!task.due_at) {
+    return null;
+  }
+  const dueDate = new Date(task.due_at);
+  const now = new Date();
+  const diffMs = dueDate.getTime() - now.getTime();
+  const diffDays = Math.round(diffMs / (1000 * 60 * 60 * 24));
+  if (diffDays === 0) {
+    return "Due today";
+  }
+  if (diffDays < 0) {
+    return `Overdue by ${Math.abs(diffDays)} day${Math.abs(diffDays) === 1 ? "" : "s"}`;
+  }
+  if (diffDays === 1) {
+    return "Due tomorrow";
+  }
+  return `Due in ${diffDays} days`;
+}
+
+function deriveFallbackAction(task: AutomationTask): string {
+  switch (task.category) {
+    case "finance":
+      return "/financials";
+    case "project":
+      return "/projects";
+    case "marketing":
+      return "/marketing";
+    case "support":
+      return "/support";
+    case "hr":
+      return "/hr";
+    case "monitoring":
+      return "/monitoring";
+    case "client":
+    default:
+      return "/clients";
+  }
+}
+
+async function getAutomationDigest(): Promise<AutomationDigest> {
+  return api.automationDigest();
+}
+
+export async function AutomationPanel(): Promise<JSX.Element> {
+  const digest = await getAutomationDigest();
+  const tasks = digest.tasks.slice(0, 6);
+
+  return (
+    <section className="card" style={{ marginTop: "3rem", display: "flex", flexDirection: "column", gap: "1rem" }}>
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: "1rem" }}>
+        <div>
+          <h3 style={{ margin: 0 }}>Automation priorities</h3>
+          <p className="text-muted" style={{ margin: 0 }}>
+            Digest generated {new Date(digest.generated_at).toLocaleString()} —
+            surface the next best actions across teams with deep links and suggested owners.
+          </p>
+        </div>
+        <Link href="/automation" style={{ color: "#38bdf8", fontWeight: 600 }}>
+          View full history →
+        </Link>
+      </div>
+      {tasks.length === 0 ? (
+        <p className="text-muted" style={{ margin: "0.5rem 0" }}>
+          All clear! The automation engine has no outstanding follow-ups at the moment.
+        </p>
+      ) : (
+        <ul style={{ listStyle: "none", margin: 0, padding: 0, display: "flex", flexDirection: "column", gap: "1rem" }}>
+          {tasks.map((task) => {
+            const dueLabel = formatDueDate(task);
+            const actionHref = task.action_url ?? deriveFallbackAction(task);
+            return (
+              <li
+                key={task.id}
+                style={{
+                  display: "flex",
+                  justifyContent: "space-between",
+                  alignItems: "flex-start",
+                  gap: "1rem",
+                  borderBottom: "1px solid rgba(148,163,184,0.2)",
+                  paddingBottom: "1rem"
+                }}
+              >
+                <div style={{ display: "flex", flexDirection: "column", gap: "0.4rem" }}>
+                  <div style={{ display: "flex", alignItems: "center", gap: "0.75rem" }}>
+                    <span className={priorityTone(task.priority)} style={{ textTransform: "uppercase", fontSize: "0.75rem" }}>
+                      {task.priority}
+                    </span>
+                    <span style={{ fontWeight: 600 }}>{task.summary}</span>
+                  </div>
+                  {task.details && <p style={{ margin: 0, color: "#cbd5f5" }}>{task.details}</p>}
+                  <div style={{ display: "flex", gap: "1.5rem", flexWrap: "wrap", fontSize: "0.85rem", color: "#94a3b8" }}>
+                    <span style={{ textTransform: "capitalize" }}>{task.category}</span>
+                    {dueLabel && <span>{dueLabel}</span>}
+                    {task.suggested_assignee && <span>Suggested: {task.suggested_assignee}</span>}
+                  </div>
+                </div>
+                <Link
+                  href={actionHref}
+                  style={{
+                    display: "inline-flex",
+                    alignItems: "center",
+                    gap: "0.5rem",
+                    padding: "0.65rem 1rem",
+                    borderRadius: "0.75rem",
+                    border: "1px solid rgba(56,189,248,0.4)",
+                    color: "#38bdf8",
+                    fontWeight: 600,
+                    textDecoration: "none"
+                  }}
+                >
+                  {task.action_label ?? "Open module"}
+                </Link>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/frontend/app/components/Sidebar.tsx
+++ b/frontend/app/components/Sidebar.tsx
@@ -6,6 +6,7 @@ import clsx from "clsx";
 
 const navItems = [
   { href: "/", label: "Overview" },
+  { href: "/automation", label: "Automation" },
   { href: "/projects", label: "Projects" },
   { href: "/clients", label: "Clients" },
   { href: "/financials", label: "Financials" },

--- a/frontend/app/hr/page.tsx
+++ b/frontend/app/hr/page.tsx
@@ -1,13 +1,44 @@
 export const dynamic = "force-dynamic";
 
-import { api, Employee } from "../../lib/api";
+import Link from "next/link";
+
+import { api, AutomationDigest, Employee, TimeOffRequest } from "../../lib/api";
 
 async function getEmployees(): Promise<Employee[]> {
   return api.employees();
 }
 
+async function getTimeOffRequests(): Promise<TimeOffRequest[]> {
+  return api.hrTimeOff();
+}
+
+async function getAutomationDigest(): Promise<AutomationDigest> {
+  return api.automationDigest();
+}
+
 export default async function PeoplePage(): Promise<JSX.Element> {
-  const employees = await getEmployees();
+  const [employees, timeOff, digest] = await Promise.all([
+    getEmployees(),
+    getTimeOffRequests(),
+    getAutomationDigest()
+  ]);
+
+  const timeOffActions = new Map<string, { label: string; url: string }>();
+  digest.tasks.forEach((task) => {
+    const requestId = task.related_ids?.time_off_request_id;
+    if (!requestId) {
+      return;
+    }
+    timeOffActions.set(requestId, {
+      label: task.action_label ?? "Review",
+      url: task.action_url ?? "/hr"
+    });
+  });
+
+  const employeeNames = new Map<string, string>();
+  employees.forEach((employee) => {
+    employeeNames.set(employee.id, `${employee.first_name} ${employee.last_name}`);
+  });
 
   return (
     <div>
@@ -37,6 +68,53 @@ export default async function PeoplePage(): Promise<JSX.Element> {
           ))}
         </tbody>
       </table>
+      <section style={{ marginTop: "2.5rem" }}>
+        <h3 style={{ marginBottom: "0.5rem" }}>Pending time-off approvals</h3>
+        <p className="text-muted" style={{ maxWidth: "640px" }}>
+          Sync automation prompts with HR workflows so managers can approve leave without context switching.
+        </p>
+        <table className="table">
+          <thead>
+            <tr>
+              <th>Team member</th>
+              <th>Dates</th>
+              <th>Status</th>
+              <th>Quick action</th>
+            </tr>
+          </thead>
+          <tbody>
+            {timeOff.length === 0 ? (
+              <tr>
+                <td colSpan={4} style={{ textAlign: "center", color: "#94a3b8" }}>
+                  No upcoming leave requests.
+                </td>
+              </tr>
+            ) : (
+              timeOff.map((request) => (
+                <tr key={request.id}>
+                  <td>{employeeNames.get(request.employee_id) ?? request.employee_id}</td>
+                  <td>
+                    {new Date(request.start_date).toLocaleDateString()} – {new Date(request.end_date).toLocaleDateString()}
+                  </td>
+                  <td style={{ textTransform: "capitalize" }}>{request.status}</td>
+                  <td>
+                    {timeOffActions.has(request.id) ? (
+                      <Link
+                        href={timeOffActions.get(request.id)!.url}
+                        style={{ color: "#38bdf8", textDecoration: "none", fontWeight: 600 }}
+                      >
+                        {timeOffActions.get(request.id)!.label}
+                      </Link>
+                    ) : (
+                      <span style={{ color: "#64748b" }}>—</span>
+                    )}
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </section>
     </div>
   );
 }

--- a/frontend/app/marketing/page.tsx
+++ b/frontend/app/marketing/page.tsx
@@ -1,13 +1,21 @@
 export const dynamic = "force-dynamic";
 
-import { api, Campaign } from "../../lib/api";
+import Link from "next/link";
+
+import { api, AutomationDigest, Campaign } from "../../lib/api";
 
 async function getCampaigns(): Promise<Campaign[]> {
   return api.campaigns();
 }
 
+async function getAutomationDigest(): Promise<AutomationDigest> {
+  return api.automationDigest();
+}
+
 export default async function MarketingPage(): Promise<JSX.Element> {
-  const campaigns = await getCampaigns();
+  const [campaigns, digest] = await Promise.all([getCampaigns(), getAutomationDigest()]);
+
+  const marketingTasks = digest.tasks.filter((task) => task.category === "marketing").slice(0, 5);
 
   return (
     <div>
@@ -37,6 +45,39 @@ export default async function MarketingPage(): Promise<JSX.Element> {
           ))}
         </tbody>
       </table>
+      <section className="card" style={{ marginTop: "2.5rem", display: "flex", flexDirection: "column", gap: "1rem" }}>
+        <div>
+          <h3 style={{ margin: 0 }}>Automation quick wins</h3>
+          <p className="text-muted" style={{ margin: 0 }}>
+            Align the content studio with automation prompts so planned assets are approved and published on time.
+          </p>
+        </div>
+        {marketingTasks.length === 0 ? (
+          <p className="text-muted" style={{ margin: 0 }}>No pending marketing automations.</p>
+        ) : (
+          <ul style={{ listStyle: "none", margin: 0, padding: 0, display: "flex", flexDirection: "column", gap: "0.75rem" }}>
+            {marketingTasks.map((task) => (
+              <li key={task.id} style={{ display: "flex", justifyContent: "space-between", gap: "1rem" }}>
+                <div>
+                  <p style={{ margin: 0, fontWeight: 600 }}>{task.summary}</p>
+                  {task.details && <p style={{ margin: "0.25rem 0", color: "#cbd5f5" }}>{task.details}</p>}
+                  {task.due_at && (
+                    <p style={{ margin: 0, fontSize: "0.85rem", color: "#94a3b8" }}>
+                      Due {new Date(task.due_at).toLocaleString()}
+                    </p>
+                  )}
+                </div>
+                <Link
+                  href={task.action_url ?? "/marketing"}
+                  style={{ color: "#38bdf8", fontWeight: 600, textDecoration: "none", alignSelf: "center" }}
+                >
+                  {task.action_label ?? "Open"}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
     </div>
   );
 }

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,6 +1,7 @@
 export const dynamic = "force-dynamic";
 
 import { api, DashboardSnapshot } from "../lib/api";
+import { AutomationPanel } from "./components/AutomationPanel";
 import { MetricCard } from "./components/MetricCard";
 
 async function getDashboard(): Promise<DashboardSnapshot> {
@@ -44,6 +45,7 @@ export default async function DashboardPage(): Promise<JSX.Element> {
           helper="Clients using secure portal"
         />
       </div>
+      <AutomationPanel />
     </div>
   );
 }

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -22,6 +22,8 @@ async function request<T>(path: string, options: ApiOptions = {}): Promise<T> {
 
 export const api = {
   dashboard: () => request<DashboardSnapshot>("/dashboard"),
+  automationDigest: () => request<AutomationDigest>("/automation/digest"),
+  automationHistory: () => request<AutomationDigest[]>("/automation/digest/history"),
   projects: () => request<Project[]>("/projects"),
   project: (projectId: string) => request<Project>(`/projects/${projectId}`),
   updateProject: (projectId: string, payload: ProjectUpdatePayload) =>
@@ -47,6 +49,7 @@ export const api = {
   financialOverview: () => request<MacroFinancials>("/financials/overview"),
   projectFinancials: () => request<ProjectFinancials[]>("/financials/projects"),
   pricingSuggestions: () => request<PricingSuggestion[]>("/financials/pricing/suggestions"),
+  taxProfile: () => request<TaxProfile>("/financials/tax/profile"),
   computeTax: (payload: TaxComputationPayload) =>
     request<TaxComputationResult>("/financials/tax/compute", {
       method: "POST",
@@ -54,6 +57,7 @@ export const api = {
     }),
   supportTickets: () => request<Ticket[]>("/support/tickets"),
   employees: () => request<Employee[]>("/hr/employees"),
+  hrTimeOff: () => request<TimeOffRequest[]>("/hr/time-off"),
   campaigns: () => request<Campaign[]>("/marketing/campaigns"),
   siteStatuses: () => request<SiteStatus[]>("/monitoring/sites")
 };
@@ -92,6 +96,36 @@ export interface DashboardSnapshot {
     avg_response_time_ms: number;
     failing_checks: number;
   };
+}
+
+export type AutomationCategory =
+  | "client"
+  | "project"
+  | "finance"
+  | "support"
+  | "marketing"
+  | "monitoring"
+  | "hr";
+
+export type AutomationPriority = "low" | "medium" | "high" | "critical";
+
+export interface AutomationTask {
+  id: string;
+  category: AutomationCategory;
+  summary: string;
+  priority: AutomationPriority;
+  due_at?: string | null;
+  suggested_assignee?: string | null;
+  details?: string | null;
+  related_ids: Record<string, string>;
+  action_label?: string | null;
+  action_url?: string | null;
+}
+
+export interface AutomationDigest {
+  id: string;
+  generated_at: string;
+  tasks: AutomationTask[];
 }
 
 export interface Project {
@@ -414,6 +448,19 @@ export interface TaxComputationResult {
   deduction_opportunities: DeductionOpportunity[];
 }
 
+export interface TaxProfile {
+  incomes: TaxEntryInput[];
+  cost_of_sales: TaxEntryInput[];
+  operating_expenses: TaxEntryInput[];
+  other_deductions: TaxEntryInput[];
+  apply_percentage_tax: boolean;
+  percentage_tax_rate: number;
+  vat_registered: boolean;
+  last_updated: string;
+  source_summary: Record<string, number>;
+  computed: TaxComputationResult;
+}
+
 export interface PricingSuggestion {
   project_id: string;
   service: string;
@@ -448,6 +495,14 @@ export interface Employee {
   email: string;
   employment_type: string;
   title: string;
+}
+
+export interface TimeOffRequest {
+  id: string;
+  employee_id: string;
+  start_date: string;
+  end_date: string;
+  status: string;
 }
 
 export interface Campaign {


### PR DESCRIPTION
## Summary
- extend the automation engine with quick-action metadata, recurring compliance heuristics, and a daily scheduler that archives digests
- expose a Philippines tax profile endpoint with seeded finance data powering deduction prompts and automation insights
- surface the automation digest throughout the dashboard, finance, support, HR, and marketing UIs with quick-action links and a new automation archive page

## Testing
- pytest
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d4257de6a08333992de0eb87fcfd8b