### PR TITLE
Refresh portal palette with pastel theme

### DIFF
--- a/frontend/app/automation/page.tsx
+++ b/frontend/app/automation/page.tsx
@@ -32,7 +32,7 @@ export default async function AutomationHistoryPage(): Promise<JSX.Element> {
         <tbody>
           {history.length === 0 ? (
             <tr>
-              <td colSpan={4} style={{ textAlign: "center", color: "#94a3b8" }}>
+              <td colSpan={4} style={{ textAlign: "center", color: "#64748b" }}>
                 No automation history recorded yet.
               </td>
             </tr>

--- a/frontend/app/components/AutomationPanel.tsx
+++ b/frontend/app/components/AutomationPanel.tsx
@@ -73,7 +73,7 @@ export async function AutomationPanel(): Promise<JSX.Element> {
             surface the next best actions across teams with deep links and suggested owners.
           </p>
         </div>
-        <Link href="/automation" style={{ color: "#38bdf8", fontWeight: 600 }}>
+        <Link href="/automation" style={{ color: "#6366f1", fontWeight: 600 }}>
           View full history →
         </Link>
       </div>
@@ -105,8 +105,8 @@ export async function AutomationPanel(): Promise<JSX.Element> {
                     </span>
                     <span style={{ fontWeight: 600 }}>{task.summary}</span>
                   </div>
-                  {task.details && <p style={{ margin: 0, color: "#cbd5f5" }}>{task.details}</p>}
-                  <div style={{ display: "flex", gap: "1.5rem", flexWrap: "wrap", fontSize: "0.85rem", color: "#94a3b8" }}>
+                  {task.details && <p style={{ margin: 0, color: "#64748b" }}>{task.details}</p>}
+                  <div style={{ display: "flex", gap: "1.5rem", flexWrap: "wrap", fontSize: "0.85rem", color: "#64748b" }}>
                     <span style={{ textTransform: "capitalize" }}>{task.category}</span>
                     {dueLabel && <span>{dueLabel}</span>}
                     {task.suggested_assignee && <span>Suggested: {task.suggested_assignee}</span>}
@@ -120,10 +120,11 @@ export async function AutomationPanel(): Promise<JSX.Element> {
                     gap: "0.5rem",
                     padding: "0.65rem 1rem",
                     borderRadius: "0.75rem",
-                    border: "1px solid rgba(56,189,248,0.4)",
-                    color: "#38bdf8",
+                    border: "1px solid rgba(129,140,248,0.4)",
+                    color: "#6366f1",
                     fontWeight: 600,
-                    textDecoration: "none"
+                    textDecoration: "none",
+                    background: "rgba(255,255,255,0.6)"
                   }}
                 >
                   {task.action_label ?? "Open module"}

--- a/frontend/app/components/MetricCard.tsx
+++ b/frontend/app/components/MetricCard.tsx
@@ -6,10 +6,10 @@ interface MetricCardProps {
 }
 
 const toneColors: Record<NonNullable<MetricCardProps["tone"]>, string> = {
-  default: "#e2e8f0",
-  success: "#4ade80",
-  warning: "#facc15",
-  danger: "#f87171"
+  default: "#4338ca",
+  success: "#16a34a",
+  warning: "#d97706",
+  danger: "#dc2626"
 };
 
 export function MetricCard({ title, value, helper, tone = "default" }: MetricCardProps): JSX.Element {
@@ -19,7 +19,7 @@ export function MetricCard({ title, value, helper, tone = "default" }: MetricCar
         {title}
       </p>
       <p style={{ fontSize: "2rem", margin: "0.25rem 0", color: toneColors[tone] }}>{value}</p>
-      {helper && <p style={{ margin: 0, color: "#94a3b8", fontSize: "0.85rem" }}>{helper}</p>}
+      {helper && <p style={{ margin: 0, color: "#64748b", fontSize: "0.85rem" }}>{helper}</p>}
     </div>
   );
 }

--- a/frontend/app/components/Sidebar.tsx
+++ b/frontend/app/components/Sidebar.tsx
@@ -24,8 +24,8 @@ export function Sidebar(): JSX.Element {
     <aside
       style={{
         width: "240px",
-        background: "rgba(15, 23, 42, 0.95)",
-        borderRight: "1px solid rgba(148,163,184,0.2)",
+        background: "linear-gradient(180deg, rgba(237, 233, 254, 0.95), rgba(255, 247, 237, 0.95))",
+        borderRight: "1px solid rgba(196, 181, 253, 0.45)",
         display: "flex",
         flexDirection: "column",
         padding: "1.5rem 1rem",
@@ -49,11 +49,14 @@ export function Sidebar(): JSX.Element {
             style={{
               padding: "0.75rem 1rem",
               borderRadius: "0.75rem",
-              color: pathname === item.href ? "#0f172a" : "#e2e8f0",
-              backgroundColor: pathname === item.href ? "#38bdf8" : "transparent",
+              color: pathname === item.href ? "#312e81" : "#475569",
+              backgroundColor: pathname === item.href
+                ? "rgba(196, 181, 253, 0.6)"
+                : "transparent",
               textDecoration: "none",
               fontWeight: 600,
-              transition: "all 0.2s ease"
+              transition: "all 0.2s ease",
+              border: pathname === item.href ? "1px solid rgba(99, 102, 241, 0.4)" : "1px solid transparent"
             }}
           >
             {item.label}

--- a/frontend/app/components/TopBar.tsx
+++ b/frontend/app/components/TopBar.tsx
@@ -12,9 +12,9 @@ export function TopBar(): JSX.Element {
         justifyContent: "space-between",
         alignItems: "center",
         padding: "1.5rem 2rem",
-        borderBottom: "1px solid rgba(148,163,184,0.2)",
-        background: "rgba(15, 23, 42, 0.8)",
-        backdropFilter: "blur(12px)",
+        borderBottom: "1px solid rgba(196, 181, 253, 0.35)",
+        background: "rgba(255, 255, 255, 0.82)",
+        backdropFilter: "blur(14px)",
         position: "sticky",
         top: 0,
         zIndex: 10
@@ -22,19 +22,19 @@ export function TopBar(): JSX.Element {
     >
       <div>
         <h2 style={{ margin: 0, fontSize: "1.5rem" }}>Unified Operations</h2>
-        <p style={{ margin: 0, color: "#94a3b8", fontSize: "0.875rem" }}>Real-time overview for Disenyorita & Isla</p>
+        <p style={{ margin: 0, color: "#64748b", fontSize: "0.875rem" }}>Real-time overview for Disenyorita & Isla</p>
       </div>
       <div style={{ display: "flex", alignItems: "center", gap: "1.5rem" }}>
-        <span style={{ fontSize: "0.875rem", color: "#cbd5f5" }}>{now}</span>
+        <span style={{ fontSize: "0.875rem", color: "#475569" }}>{now}</span>
         <div
           style={{
             display: "flex",
             gap: "0.5rem",
-            background: "rgba(56, 189, 248, 0.1)",
+            background: "rgba(129, 140, 248, 0.18)",
             borderRadius: "9999px",
             padding: "0.35rem 0.75rem",
             fontSize: "0.75rem",
-            color: "#38bdf8",
+            color: "#6366f1",
             fontWeight: 600
           }}
         >

--- a/frontend/app/financials/page.tsx
+++ b/frontend/app/financials/page.tsx
@@ -129,10 +129,10 @@ export default async function FinancialsPage(): Promise<JSX.Element> {
                 <td>{formatCurrency(record.total_invoiced, record.currency)}</td>
                 <td>{formatCurrency(record.total_collected, record.currency)}</td>
                 <td>{formatCurrency(record.total_expenses, record.currency)}</td>
-                <td style={{ color: record.outstanding_amount > 0 ? "#facc15" : "#94a3b8" }}>
+                <td style={{ color: record.outstanding_amount > 0 ? "#fcd34d" : "#64748b" }}>
                   {formatCurrency(record.outstanding_amount, record.currency)}
                 </td>
-                <td style={{ color: record.net_revenue >= 0 ? "#4ade80" : "#f87171" }}>
+                <td style={{ color: record.net_revenue >= 0 ? "#16a34a" : "#fb7185" }}>
                   {formatCurrency(record.net_revenue, record.currency)}
                 </td>
               </tr>
@@ -176,7 +176,7 @@ export default async function FinancialsPage(): Promise<JSX.Element> {
                     <Link
                       href={reminderTasks.get(invoice.id)!.url}
                       style={{
-                        color: "#38bdf8",
+                        color: "#6366f1",
                         textDecoration: "none",
                         fontWeight: 600
                       }}
@@ -213,7 +213,7 @@ export default async function FinancialsPage(): Promise<JSX.Element> {
           <tbody>
             {pricingSuggestions.length === 0 ? (
               <tr>
-                <td colSpan={6} style={{ textAlign: "center", color: "#94a3b8" }}>
+                <td colSpan={6} style={{ textAlign: "center", color: "#64748b" }}>
                   No pricing suggestions available yet. Add financial data to generate insights.
                 </td>
               </tr>
@@ -244,7 +244,7 @@ export default async function FinancialsPage(): Promise<JSX.Element> {
             display: "inline-flex",
             alignItems: "center",
             gap: "0.5rem",
-            color: "#38bdf8",
+            color: "#6366f1",
             fontWeight: 600,
             textDecoration: "none"
           }}

--- a/frontend/app/financials/tax-calculator/page.tsx
+++ b/frontend/app/financials/tax-calculator/page.tsx
@@ -92,9 +92,9 @@ function EntryList({
             style={{
               padding: "0.75rem",
               borderRadius: "0.75rem",
-              border: "1px solid rgba(148,163,184,0.2)",
-              background: "rgba(15,23,42,0.6)",
-              color: "#e2e8f0"
+              border: "1px solid rgba(148,163,184,0.45)",
+              background: "rgba(255,255,255,0.9)",
+              color: "#1f2937"
             }}
           />
           <input
@@ -105,9 +105,9 @@ function EntryList({
             style={{
               padding: "0.75rem",
               borderRadius: "0.75rem",
-              border: "1px solid rgba(148,163,184,0.2)",
-              background: "rgba(15,23,42,0.6)",
-              color: "#e2e8f0"
+              border: "1px solid rgba(148,163,184,0.45)",
+              background: "rgba(255,255,255,0.9)",
+              color: "#1f2937"
             }}
           />
           <button
@@ -117,7 +117,7 @@ function EntryList({
             style={{
               border: "none",
               background: "transparent",
-              color: "#94a3b8",
+              color: "#cbd5f5",
               fontSize: "1.25rem",
               cursor: "pointer"
             }}
@@ -132,9 +132,9 @@ function EntryList({
         style={{
           padding: "0.75rem 1rem",
           borderRadius: "0.75rem",
-          border: "1px solid rgba(56,189,248,0.4)",
-          background: "transparent",
-          color: "#38bdf8",
+          border: "1px solid rgba(129,140,248,0.4)",
+          background: "rgba(255,255,255,0.6)",
+          color: "#6366f1",
           fontWeight: 600,
           cursor: "pointer"
         }}
@@ -268,7 +268,7 @@ export default function TaxCalculatorPage(): JSX.Element {
 
   return (
     <div>
-      <Link href="/financials" style={{ color: "#38bdf8", textDecoration: "none", fontWeight: 600 }}>
+      <Link href="/financials" style={{ color: "#6366f1", textDecoration: "none", fontWeight: 600 }}>
         ← Back to financial control
       </Link>
       <h2 className="section-title" style={{ marginTop: "1.5rem" }}>
@@ -345,9 +345,9 @@ export default function TaxCalculatorPage(): JSX.Element {
               style={{
                 padding: "0.75rem",
                 borderRadius: "0.75rem",
-                border: "1px solid rgba(148,163,184,0.2)",
-                background: "rgba(15,23,42,0.6)",
-                color: "#e2e8f0"
+                border: "1px solid rgba(148,163,184,0.45)",
+                background: "rgba(255,255,255,0.9)",
+                color: "#1f2937"
               }}
             >
               <option value={1}>1% (CREATE relief for MSMEs)</option>
@@ -368,15 +368,18 @@ export default function TaxCalculatorPage(): JSX.Element {
             padding: "0.85rem 1.5rem",
             borderRadius: "0.75rem",
             border: "none",
-            background: loading ? "rgba(148,163,184,0.4)" : "#38bdf8",
-            color: loading ? "#0f172a" : "#0f172a",
+            background: loading
+              ? "rgba(203, 213, 225, 0.7)"
+              : "linear-gradient(135deg, #a5b4fc, #fbcfe8)",
+            color: loading ? "#475569" : "#312e81",
             fontWeight: 700,
-            cursor: loading ? "not-allowed" : "pointer"
+            cursor: loading ? "not-allowed" : "pointer",
+            boxShadow: loading ? "none" : "0 16px 32px rgba(165, 180, 252, 0.35)"
           }}
         >
           {loading ? "Calculating…" : "Recalculate tax obligations"}
         </button>
-        {error && <p style={{ color: "#f87171", margin: 0 }}>{error}</p>}
+        {error && <p style={{ color: "#fb7185", margin: 0 }}>{error}</p>}
       </div>
 
       <div className="card" style={{ marginTop: "2.5rem", display: "flex", flexDirection: "column", gap: "1rem" }}>
@@ -388,11 +391,11 @@ export default function TaxCalculatorPage(): JSX.Element {
           </div>
           <div>
             <p className="text-muted" style={{ margin: 0 }}>Total expenses</p>
-            <p style={{ fontSize: "1.4rem", margin: "0.25rem 0", color: "#f97316" }}>{formatCurrency(totalExpenses)}</p>
+            <p style={{ fontSize: "1.4rem", margin: "0.25rem 0", color: "#fb7185" }}>{formatCurrency(totalExpenses)}</p>
           </div>
           <div>
             <p className="text-muted" style={{ margin: 0 }}>Allowable deductions</p>
-            <p style={{ fontSize: "1.4rem", margin: "0.25rem 0", color: "#facc15" }}>{formatCurrency(totalDeductions)}</p>
+            <p style={{ fontSize: "1.4rem", margin: "0.25rem 0", color: "#fcd34d" }}>{formatCurrency(totalDeductions)}</p>
           </div>
           <div>
             <p className="text-muted" style={{ margin: 0 }}>Projected taxable income</p>
@@ -409,25 +412,25 @@ export default function TaxCalculatorPage(): JSX.Element {
           <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(200px, 1fr))", gap: "1rem" }}>
             <div>
               <p className="text-muted" style={{ margin: 0 }}>Income tax</p>
-              <p style={{ fontSize: "1.5rem", margin: "0.25rem 0", color: "#f97316" }}>
+              <p style={{ fontSize: "1.5rem", margin: "0.25rem 0", color: "#fb7185" }}>
                 {formatCurrency(calculation.income_tax)}
               </p>
             </div>
             <div>
               <p className="text-muted" style={{ margin: 0 }}>Percentage tax</p>
-              <p style={{ fontSize: "1.5rem", margin: "0.25rem 0", color: "#facc15" }}>
+              <p style={{ fontSize: "1.5rem", margin: "0.25rem 0", color: "#fcd34d" }}>
                 {formatCurrency(calculation.percentage_tax)}
               </p>
             </div>
             <div>
               <p className="text-muted" style={{ margin: 0 }}>VAT due</p>
-              <p style={{ fontSize: "1.5rem", margin: "0.25rem 0", color: "#38bdf8" }}>
+              <p style={{ fontSize: "1.5rem", margin: "0.25rem 0", color: "#60a5fa" }}>
                 {formatCurrency(calculation.vat_due)}
               </p>
             </div>
             <div>
               <p className="text-muted" style={{ margin: 0 }}>Total estimated tax</p>
-              <p style={{ fontSize: "1.5rem", margin: "0.25rem 0", color: "#f87171" }}>
+              <p style={{ fontSize: "1.5rem", margin: "0.25rem 0", color: "#fb7185" }}>
                 {formatCurrency(calculation.total_tax)}
               </p>
             </div>
@@ -455,7 +458,7 @@ export default function TaxCalculatorPage(): JSX.Element {
                 <strong style={{ textTransform: "uppercase", letterSpacing: "0.05em", fontSize: "0.75rem" }}>
                   {tip.category}
                 </strong>
-                <p style={{ margin: "0.25rem 0 0", color: "#cbd5f5" }}>{tip.message}</p>
+                <p style={{ margin: "0.25rem 0 0", color: "#64748b" }}>{tip.message}</p>
               </li>
             ))}
           </ul>

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -1,7 +1,7 @@
 :root {
   color-scheme: light;
   font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-  background-color: #0f172a;
+  background-color: #f5f3ff;
 }
 
 * {
@@ -10,8 +10,8 @@
 
 body {
   margin: 0;
-  background: #0f172a;
-  color: #e2e8f0;
+  background: linear-gradient(160deg, #f5f3ff 0%, #fef6f9 100%);
+  color: #334155;
 }
 
 main {
@@ -39,11 +39,11 @@ main {
 }
 
 .card {
-  background: rgba(15, 23, 42, 0.8);
-  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: rgba(255, 255, 255, 0.92);
+  border: 1px solid rgba(148, 163, 184, 0.25);
   border-radius: 1rem;
   padding: 1.5rem;
-  box-shadow: 0 15px 35px rgba(15, 23, 42, 0.35);
+  box-shadow: 0 12px 30px rgba(148, 163, 184, 0.18);
 }
 
 .card h3 {
@@ -53,7 +53,7 @@ main {
 }
 
 .text-muted {
-  color: #94a3b8;
+  color: #64748b;
 }
 
 .table {
@@ -66,7 +66,7 @@ main {
 .table td {
   padding: 0.75rem 1rem;
   text-align: left;
-  border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+  border-bottom: 1px solid rgba(148, 163, 184, 0.18);
 }
 
 .badge {
@@ -79,18 +79,18 @@ main {
 }
 
 .badge.success {
-  background: rgba(34, 197, 94, 0.2);
-  color: #4ade80;
+  background: rgba(187, 247, 208, 0.7);
+  color: #15803d;
 }
 
 .badge.warning {
-  background: rgba(250, 204, 21, 0.2);
-  color: #facc15;
+  background: rgba(254, 243, 199, 0.7);
+  color: #b45309;
 }
 
 .badge.danger {
-  background: rgba(248, 113, 113, 0.2);
-  color: #f87171;
+  background: rgba(254, 202, 202, 0.7);
+  color: #b91c1c;
 }
 
 .section-title {
@@ -141,24 +141,25 @@ main {
 }
 
 .button.primary {
-  background: linear-gradient(135deg, #38bdf8, #8b5cf6);
-  color: #0f172a;
-  box-shadow: 0 12px 20px rgba(56, 189, 248, 0.25);
+  background: linear-gradient(135deg, #a5b4fc, #fbcfe8);
+  color: #312e81;
+  box-shadow: 0 12px 24px rgba(165, 180, 252, 0.35);
 }
 
 .button.primary:hover {
   transform: translateY(-1px);
-  box-shadow: 0 18px 28px rgba(56, 189, 248, 0.35);
+  box-shadow: 0 18px 36px rgba(165, 180, 252, 0.45);
 }
 
 .button.ghost {
   background: transparent;
-  border-color: rgba(148, 163, 184, 0.4);
-  color: #e2e8f0;
+  border-color: rgba(148, 163, 184, 0.45);
+  color: #475569;
 }
 
 .button.ghost:hover {
-  border-color: rgba(148, 163, 184, 0.7);
+  border-color: rgba(79, 70, 229, 0.45);
+  color: #3730a3;
 }
 
 .form {
@@ -168,15 +169,16 @@ main {
 }
 
 .form-section {
-  border: 1px solid rgba(148, 163, 184, 0.2);
+  border: 1px solid rgba(148, 163, 184, 0.25);
   border-radius: 1rem;
   padding: 1.25rem;
+  background: rgba(255, 255, 255, 0.85);
 }
 
 .form-section legend {
   padding: 0 0.5rem;
   font-weight: 600;
-  color: #cbd5f5;
+  color: #4338ca;
 }
 
 .form-grid {
@@ -202,17 +204,17 @@ main {
 .form-grid textarea {
   padding: 0.65rem 0.75rem;
   border-radius: 0.75rem;
-  border: 1px solid rgba(148, 163, 184, 0.25);
-  background: rgba(15, 23, 42, 0.7);
-  color: #f8fafc;
+  border: 1px solid rgba(148, 163, 184, 0.45);
+  background: rgba(255, 255, 255, 0.9);
+  color: #1f2937;
 }
 
 .form-grid input:focus,
 .form-grid select:focus,
 .form-grid textarea:focus {
   outline: none;
-  border-color: rgba(56, 189, 248, 0.75);
-  box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.2);
+  border-color: rgba(129, 140, 248, 0.95);
+  box-shadow: 0 0 0 3px rgba(196, 181, 253, 0.4);
 }
 
 .form-actions {
@@ -226,18 +228,18 @@ main {
 }
 
 .form-feedback.error {
-  color: #f87171;
+  color: #dc2626;
 }
 
 .form-feedback.success {
-  color: #4ade80;
+  color: #16a34a;
 }
 
 .modal-backdrop {
   position: fixed;
   inset: 0;
-  background: rgba(15, 23, 42, 0.78);
-  backdrop-filter: blur(6px);
+  background: rgba(148, 163, 184, 0.45);
+  backdrop-filter: blur(10px);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -247,10 +249,10 @@ main {
 
 .modal {
   width: min(720px, 100%);
-  background: rgba(15, 23, 42, 0.95);
+  background: rgba(255, 255, 255, 0.95);
   border-radius: 1.5rem;
-  border: 1px solid rgba(148, 163, 184, 0.25);
-  box-shadow: 0 28px 60px rgba(15, 23, 42, 0.45);
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  box-shadow: 0 28px 60px rgba(148, 163, 184, 0.25);
   padding: 1.75rem;
   max-height: calc(100vh - 4rem);
   overflow-y: auto;
@@ -269,15 +271,15 @@ main {
 }
 
 .clickable-row:hover {
-  background: rgba(148, 163, 184, 0.08);
+  background: rgba(196, 181, 253, 0.18);
 }
 
 .clickable-row.active {
-  background: rgba(56, 189, 248, 0.12);
+  background: rgba(196, 181, 253, 0.3);
 }
 
 .clickable-row.active:hover {
-  background: rgba(56, 189, 248, 0.18);
+  background: rgba(165, 180, 252, 0.35);
 }
 
 .back-link {
@@ -285,12 +287,12 @@ main {
   align-items: center;
   gap: 0.5rem;
   margin-bottom: 1rem;
-  color: #38bdf8;
+  color: #818cf8;
   text-decoration: none;
 }
 
 .back-link:hover {
-  color: #0ea5e9;
+  color: #6366f1;
 }
 
 .client-detail {
@@ -320,7 +322,7 @@ main {
   font-size: 0.85rem;
   text-transform: uppercase;
   letter-spacing: 0.08em;
-  color: #94a3b8;
+  color: #64748b;
 }
 
 .definition-list dd {
@@ -341,11 +343,11 @@ main {
   justify-content: space-between;
   align-items: baseline;
   padding: 0.75rem 0;
-  border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+  border-bottom: 1px solid rgba(148, 163, 184, 0.18);
 }
 
 .metric span {
-  color: #94a3b8;
+  color: #64748b;
   text-transform: uppercase;
   font-size: 0.75rem;
   letter-spacing: 0.08em;

--- a/frontend/app/hr/page.tsx
+++ b/frontend/app/hr/page.tsx
@@ -85,7 +85,7 @@ export default async function PeoplePage(): Promise<JSX.Element> {
           <tbody>
             {timeOff.length === 0 ? (
               <tr>
-                <td colSpan={4} style={{ textAlign: "center", color: "#94a3b8" }}>
+                <td colSpan={4} style={{ textAlign: "center", color: "#64748b" }}>
                   No upcoming leave requests.
                 </td>
               </tr>
@@ -101,7 +101,7 @@ export default async function PeoplePage(): Promise<JSX.Element> {
                     {timeOffActions.has(request.id) ? (
                       <Link
                         href={timeOffActions.get(request.id)!.url}
-                        style={{ color: "#38bdf8", textDecoration: "none", fontWeight: 600 }}
+                        style={{ color: "#6366f1", textDecoration: "none", fontWeight: 600 }}
                       >
                         {timeOffActions.get(request.id)!.label}
                       </Link>

--- a/frontend/app/marketing/page.tsx
+++ b/frontend/app/marketing/page.tsx
@@ -60,16 +60,16 @@ export default async function MarketingPage(): Promise<JSX.Element> {
               <li key={task.id} style={{ display: "flex", justifyContent: "space-between", gap: "1rem" }}>
                 <div>
                   <p style={{ margin: 0, fontWeight: 600 }}>{task.summary}</p>
-                  {task.details && <p style={{ margin: "0.25rem 0", color: "#cbd5f5" }}>{task.details}</p>}
+                  {task.details && <p style={{ margin: "0.25rem 0", color: "#64748b" }}>{task.details}</p>}
                   {task.due_at && (
-                    <p style={{ margin: 0, fontSize: "0.85rem", color: "#94a3b8" }}>
+                    <p style={{ margin: 0, fontSize: "0.85rem", color: "#64748b" }}>
                       Due {new Date(task.due_at).toLocaleString()}
                     </p>
                   )}
                 </div>
                 <Link
                   href={task.action_url ?? "/marketing"}
-                  style={{ color: "#38bdf8", fontWeight: 600, textDecoration: "none", alignSelf: "center" }}
+                  style={{ color: "#6366f1", fontWeight: 600, textDecoration: "none", alignSelf: "center" }}
                 >
                   {task.action_label ?? "Open"}
                 </Link>

--- a/frontend/app/support/page.tsx
+++ b/frontend/app/support/page.tsx
@@ -69,7 +69,7 @@ export default async function SupportPage(): Promise<JSX.Element> {
                 {ticketActions.has(ticket.id) ? (
                   <Link
                     href={ticketActions.get(ticket.id)!.url}
-                    style={{ color: "#38bdf8", textDecoration: "none", fontWeight: 600 }}
+                    style={{ color: "#6366f1", textDecoration: "none", fontWeight: 600 }}
                   >
                     {ticketActions.get(ticket.id)!.label}
                   </Link>


### PR DESCRIPTION
## Summary
- restyle the global shell with a light pastel gradient, softer card surfaces, and updated badge/button colors
- align shared components such as the sidebar, top bar, and metric cards with the new accent palette
- refresh financial, automation, HR, marketing, and support screens to use consistent pastel highlights and links

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d4467bc9648333a78d4dc0c366492b