### PR TITLE
Add calendar and Gantt toggles to project dashboard

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -338,6 +338,159 @@ main {
   margin: 0;
 }
 
+.timeline-toolbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 1rem;
+}
+
+.timeline-toggle {
+  display: inline-flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.button.ghost.active {
+  border-color: rgba(79, 70, 229, 0.6);
+  background: rgba(165, 180, 252, 0.22);
+  color: #3730a3;
+}
+
+.timeline-visual {
+  margin-top: 1.5rem;
+}
+
+.gantt-wrapper {
+  display: grid;
+  gap: 1rem;
+}
+
+.gantt-range {
+  font-size: 0.85rem;
+  color: #64748b;
+}
+
+.gantt-rows {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.gantt-row {
+  display: grid;
+  gap: 1rem;
+  align-items: center;
+}
+
+@media (min-width: 768px) {
+  .gantt-row {
+    grid-template-columns: minmax(180px, 220px) 1fr;
+  }
+}
+
+.gantt-track {
+  position: relative;
+  height: 0.75rem;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.25);
+  overflow: hidden;
+}
+
+.gantt-bar {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  border-radius: 999px;
+  background: linear-gradient(135deg, #a5b4fc, #fbcfe8);
+  box-shadow: 0 8px 16px rgba(165, 180, 252, 0.35);
+}
+
+.calendar-wrapper {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.calendar-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.calendar-header-title {
+  font-weight: 600;
+  font-size: 1rem;
+  color: #4338ca;
+}
+
+.calendar-grid {
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  gap: 0.5rem;
+}
+
+.calendar-grid--labels .calendar-label {
+  text-align: center;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #94a3b8;
+}
+
+.calendar-day {
+  background: rgba(255, 255, 255, 0.9);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 0.75rem;
+  padding: 0.5rem;
+  min-height: 110px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  box-shadow: 0 8px 18px rgba(148, 163, 184, 0.12);
+}
+
+.calendar-day.muted {
+  opacity: 0.45;
+}
+
+.calendar-date {
+  font-weight: 600;
+  color: #475569;
+}
+
+.calendar-task {
+  font-size: 0.75rem;
+  padding: 0.25rem 0.5rem;
+  border-radius: 999px;
+  font-weight: 600;
+  background: rgba(148, 163, 184, 0.3);
+  color: #475569;
+}
+
+.calendar-task.status-in_progress {
+  background: rgba(253, 230, 138, 0.4);
+  color: #92400e;
+}
+
+.calendar-task.status-review {
+  background: rgba(196, 181, 253, 0.4);
+  color: #6d28d9;
+}
+
+.calendar-task.status-done {
+  background: rgba(187, 247, 208, 0.55);
+  color: #15803d;
+}
+
+.calendar-task.status-todo {
+  background: rgba(148, 163, 184, 0.3);
+  color: #475569;
+}
+
 .metric {
   display: flex;
   justify-content: space-between;


### PR DESCRIPTION
## Summary
- add a timeline view toggle on the project dashboard to switch between gantt and calendar visualizations
- derive task timeline metadata so gantt bars and calendar groupings stay in sync with in-progress edits
- style the new timeline components with responsive layout, badge accents, and toggle affordances

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d9b1d2a470833385060d2169ad21dd