### PR TITLE
Add operations snapshot control tower

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Disenyorita & Isla Unified Operations Platform
 
 ## Executive Summary
-The repository currently contains only a placeholder README, so the project will need a full greenfield implementation. Below is a comprehensive product and technical specification for an all-in-one platform serving both Disenyorita (web/branding) and Isla (hospitality consulting). This blueprint is structured so ChatGPT Codex—or any development team—can translate it into production-grade code while emphasizing usability, modularity, and security.
+This repository now ships with a working proof-of-concept. The FastAPI backend exposes a unified operations snapshot (cash runway, delivery risks, capacity alerts, monitoring incidents) and the Next.js front-end renders a control tower dashboard for both the studio and hospitality consulting teams. Below is a comprehensive product and technical specification for an all-in-one platform serving both Disenyorita (web/branding) and Isla (hospitality consulting). This blueprint is structured so ChatGPT Codex—or any development team—can translate it into production-grade code while emphasizing usability, modularity, and security.
 
 ## Core Product Modules
 

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,0 +1,14 @@
+import inspect
+from typing import ForwardRef
+
+_forward_ref_signature = inspect.signature(ForwardRef._evaluate)
+if "recursive_guard" in _forward_ref_signature.parameters:  # pragma: no cover - compatibility shim
+    _original_forward_ref_evaluate = ForwardRef._evaluate
+
+    def _patched_forward_ref_evaluate(self, globalns, localns, *args, **kwargs):
+        if "recursive_guard" not in kwargs and args:
+            kwargs["recursive_guard"] = args[-1]
+            args = args[:-1]
+        return _original_forward_ref_evaluate(self, globalns, localns, *args, **kwargs)
+
+    ForwardRef._evaluate = _patched_forward_ref_evaluate

--- a/backend/app/api/routes/dashboard.py
+++ b/backend/app/api/routes/dashboard.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter
 
 from ...schemas.dashboard import DashboardSnapshot
+from ...schemas.operations import OperationsSnapshot
 from ...services.data import store
 
 router = APIRouter(prefix="/dashboard", tags=["dashboard"])
@@ -16,3 +17,8 @@ def get_dashboard_snapshot() -> DashboardSnapshot:
         marketing=store.marketing_summary(),
         monitoring=store.monitoring_summary(),
     )
+
+
+@router.get("/operations", response_model=OperationsSnapshot)
+def get_operations_snapshot() -> OperationsSnapshot:
+    return store.operations_snapshot()

--- a/backend/app/schemas/operations.py
+++ b/backend/app/schemas/operations.py
@@ -1,0 +1,70 @@
+from datetime import date, datetime
+from datetime import date, datetime
+from typing import List, Optional
+
+from pydantic import BaseModel, Field
+
+from .hr import TimeOffStatus
+from .projects import ProjectHealth
+
+
+class CashRunway(BaseModel):
+    total_cash_on_hand: float
+    monthly_burn_rate: float
+    runway_days: Optional[int]
+    outstanding_invoices: float
+    upcoming_payables: float
+    collection_rate: float
+
+
+class OperationsProject(BaseModel):
+    project_id: str
+    project_name: str
+    client_name: Optional[str]
+    health: ProjectHealth
+    progress: float
+    late_tasks: int
+    next_milestone_title: Optional[str]
+    next_milestone_due: Optional[datetime]
+
+
+class CapacityAlert(BaseModel):
+    employee_id: str
+    employee_name: str
+    available_hours: float
+    billable_ratio: float
+    reason: str
+
+
+class TimeOffWindow(BaseModel):
+    employee_id: str
+    employee_name: str
+    start_date: date
+    end_date: date
+    status: TimeOffStatus
+
+
+class MonitoringIncident(BaseModel):
+    site_id: str
+    site_label: str
+    severity: str
+    triggered_at: datetime
+    message: str
+    acknowledged: bool
+
+
+class OperationsRecommendation(BaseModel):
+    title: str
+    description: str
+    category: str
+    impact: str
+
+
+class OperationsSnapshot(BaseModel):
+    generated_at: datetime
+    cash: CashRunway
+    at_risk_projects: List[OperationsProject] = Field(default_factory=list)
+    capacity_alerts: List[CapacityAlert] = Field(default_factory=list)
+    upcoming_time_off: List[TimeOffWindow] = Field(default_factory=list)
+    monitoring_incidents: List[MonitoringIncident] = Field(default_factory=list)
+    recommendations: List[OperationsRecommendation] = Field(default_factory=list)

--- a/backend/tests/test_dashboard.py
+++ b/backend/tests/test_dashboard.py
@@ -1,0 +1,43 @@
+import inspect
+import sys
+from pathlib import Path
+from typing import ForwardRef
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+_forward_ref_signature = inspect.signature(ForwardRef._evaluate)
+if "recursive_guard" in _forward_ref_signature.parameters:
+    _original_forward_ref_evaluate = ForwardRef._evaluate
+
+    def _patched_forward_ref_evaluate(self, globalns, localns, *args, **kwargs):
+        if "recursive_guard" not in kwargs and args:
+            kwargs["recursive_guard"] = args[-1]
+            args = args[:-1]
+        return _original_forward_ref_evaluate(self, globalns, localns, *args, **kwargs)
+
+    ForwardRef._evaluate = _patched_forward_ref_evaluate
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from app.main import app  # noqa: E402
+
+client = TestClient(app)
+
+
+def test_operations_snapshot_exposes_risk_hotspots() -> None:
+    response = client.get("/api/v1/dashboard/operations")
+    response.raise_for_status()
+    payload = response.json()
+
+    cash = payload["cash"]
+    assert cash["runway_days"] is not None
+    assert cash["monthly_burn_rate"] > 0
+    assert cash["collection_rate"] <= 1
+
+    assert payload["at_risk_projects"], "Expected at least one project flagged as at-risk"
+    assert payload["capacity_alerts"], "Expected at least one capacity alert"
+    assert payload["monitoring_incidents"], "Expected monitoring incidents to be surfaced"
+    assert payload["upcoming_time_off"], "Expected upcoming time-off windows"
+
+    recommendation_categories = {recommendation["category"] for recommendation in payload["recommendations"]}
+    assert {"finance", "projects", "technology"}.issubset(recommendation_categories)

--- a/frontend/app/components/OperationsPanel.tsx
+++ b/frontend/app/components/OperationsPanel.tsx
@@ -1,0 +1,193 @@
+import { api, CapacityAlert, MonitoringIncident, OperationsProject, OperationsSnapshot, TimeOffWindow } from "../../lib/api";
+
+function formatCurrency(amount: number): string {
+  return new Intl.NumberFormat("en-US", { style: "currency", currency: "USD", maximumFractionDigits: 0 }).format(amount);
+}
+
+function formatRunway(days: number | null): string {
+  if (days === null) {
+    return "Not enough data";
+  }
+  if (days <= 30) {
+    return `${days} day${days === 1 ? "" : "s"}`;
+  }
+  const months = Math.floor(days / 30);
+  const remainingDays = days % 30;
+  if (remainingDays === 0) {
+    return `${months} month${months === 1 ? "" : "s"}`;
+  }
+  return `${months}m ${remainingDays}d`;
+}
+
+function formatDate(value: string): string {
+  return new Date(value).toLocaleDateString(undefined, { month: "short", day: "numeric" });
+}
+
+function toneForSeverity(incident: MonitoringIncident): string {
+  switch (incident.severity) {
+    case "critical":
+      return "badge danger";
+    case "warning":
+      return "badge warning";
+    default:
+      return "badge";
+  }
+}
+
+function capacitySummary(alerts: CapacityAlert[]): string {
+  if (alerts.length === 0) {
+    return "All team members have adequate buffer.";
+  }
+  const tightest = alerts[0];
+  return `${alerts.length} team member${alerts.length === 1 ? "" : "s"} nearing capacity — ${
+    tightest.employee_name
+  } has only ${Math.round(tightest.available_hours)}h free.`;
+}
+
+async function getOperations(): Promise<OperationsSnapshot> {
+  return api.operations();
+}
+
+export async function OperationsPanel(): Promise<JSX.Element> {
+  const snapshot = await getOperations();
+  const runwayLabel = formatRunway(snapshot.cash.runway_days);
+  const collectionRate = Math.round(snapshot.cash.collection_rate * 100);
+
+  return (
+    <section style={{ display: "flex", flexDirection: "column", gap: "1.5rem", marginTop: "3rem" }}>
+      <div className="grid-two">
+        <div className="card" style={{ display: "flex", flexDirection: "column", gap: "1.25rem" }}>
+          <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", gap: "1rem" }}>
+            <div>
+              <h3 style={{ margin: 0 }}>Cash runway</h3>
+              <p className="text-muted" style={{ margin: 0 }}>
+                Live view of the combined studio + hospitality cash position.
+              </p>
+            </div>
+            <span className="badge warning" style={{ textTransform: "uppercase", letterSpacing: "0.08em" }}>
+              {runwayLabel}
+            </span>
+          </div>
+          <div style={{ display: "grid", gap: "0.75rem", gridTemplateColumns: "repeat(2, minmax(0, 1fr))" }}>
+            <div>
+              <p className="text-muted" style={{ margin: 0 }}>Cash on hand</p>
+              <strong style={{ fontSize: "1.4rem" }}>{formatCurrency(snapshot.cash.total_cash_on_hand)}</strong>
+            </div>
+            <div>
+              <p className="text-muted" style={{ margin: 0 }}>Monthly burn</p>
+              <strong style={{ fontSize: "1.4rem" }}>{formatCurrency(snapshot.cash.monthly_burn_rate)}</strong>
+            </div>
+            <div>
+              <p className="text-muted" style={{ margin: 0 }}>Outstanding invoices</p>
+              <strong>{formatCurrency(snapshot.cash.outstanding_invoices)}</strong>
+            </div>
+            <div>
+              <p className="text-muted" style={{ margin: 0 }}>Collection rate</p>
+              <strong>{collectionRate}%</strong>
+            </div>
+          </div>
+          <div>
+            <h4 style={{ margin: "0 0 0.5rem 0" }}>Recommended actions</h4>
+            <ul className="plain-list">
+              {snapshot.recommendations.map((recommendation) => (
+                <li key={`${recommendation.category}-${recommendation.title}`}>
+                  <span style={{ fontWeight: 600 }}>{recommendation.title}</span>
+                  <p className="text-muted" style={{ margin: "0.25rem 0 0 0" }}>
+                    {recommendation.description}
+                  </p>
+                </li>
+              ))}
+            </ul>
+          </div>
+          <p className="text-muted" style={{ margin: 0, fontSize: "0.8rem" }}>
+            Generated {new Date(snapshot.generated_at).toLocaleString()}.
+          </p>
+        </div>
+        <div className="card" style={{ display: "flex", flexDirection: "column", gap: "1rem" }}>
+          <div>
+            <h3 style={{ margin: 0 }}>Delivery watchlist</h3>
+            <p className="text-muted" style={{ margin: 0 }}>{capacitySummary(snapshot.capacity_alerts)}</p>
+          </div>
+          <div>
+            <h4 style={{ margin: "0 0 0.5rem 0" }}>Projects at risk</h4>
+            {snapshot.at_risk_projects.length === 0 ? (
+              <p className="text-muted" style={{ margin: 0 }}>No active delivery risks right now.</p>
+            ) : (
+              <ul className="plain-list">
+                {snapshot.at_risk_projects.map((project: OperationsProject) => (
+                  <li key={project.project_id} style={{ display: "flex", flexDirection: "column", gap: "0.2rem" }}>
+                    <div style={{ display: "flex", justifyContent: "space-between", gap: "0.5rem" }}>
+                      <span style={{ fontWeight: 600 }}>{project.project_name}</span>
+                      <span className="badge danger" style={{ textTransform: "capitalize" }}>
+                        {project.health.replace("_", " ")}
+                      </span>
+                    </div>
+                    <p className="text-muted" style={{ margin: 0 }}>
+                      {project.client_name ?? "Unassigned client"} • {project.late_tasks} late task{project.late_tasks === 1 ? "" : "s"}
+                      {project.next_milestone_title
+                        ? ` • Next milestone "${project.next_milestone_title}" on ${formatDate(project.next_milestone_due ?? "")}`
+                        : ""}
+                    </p>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+          <div>
+            <h4 style={{ margin: "0 0 0.5rem 0" }}>Monitoring incidents</h4>
+            {snapshot.monitoring_incidents.length === 0 ? (
+              <p className="text-muted" style={{ margin: 0 }}>All monitored assets are healthy.</p>
+            ) : (
+              <ul className="plain-list">
+                {snapshot.monitoring_incidents.map((incident: MonitoringIncident) => (
+                  <li key={`${incident.site_id}-${incident.triggered_at}`} style={{ display: "flex", flexDirection: "column", gap: "0.25rem" }}>
+                    <div style={{ display: "flex", justifyContent: "space-between", gap: "0.5rem" }}>
+                      <span style={{ fontWeight: 600 }}>{incident.site_label}</span>
+                      <span className={toneForSeverity(incident)} style={{ textTransform: "capitalize" }}>
+                        {incident.severity}
+                      </span>
+                    </div>
+                    <p className="text-muted" style={{ margin: 0 }}>{incident.message}</p>
+                    <span style={{ fontSize: "0.8rem", color: "#94a3b8" }}>
+                      Triggered {new Date(incident.triggered_at).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        </div>
+      </div>
+      <div className="card" style={{ display: "flex", flexDirection: "column", gap: "1rem" }}>
+        <div>
+          <h3 style={{ margin: 0 }}>Team schedule</h3>
+          <p className="text-muted" style={{ margin: 0 }}>
+            Keep stakeholders informed about who is away before you commit to new deliverables.
+          </p>
+        </div>
+        <div className="table-scroll">
+          <table className="table">
+            <thead>
+              <tr>
+                <th>Team member</th>
+                <th>Status</th>
+                <th>Window</th>
+              </tr>
+            </thead>
+            <tbody>
+              {snapshot.upcoming_time_off.map((window: TimeOffWindow) => (
+                <tr key={`${window.employee_id}-${window.start_date}`}>
+                  <td>{window.employee_name}</td>
+                  <td style={{ textTransform: "capitalize" }}>{window.status.replace("_", " ")}</td>
+                  <td>
+                    {formatDate(window.start_date)} → {formatDate(window.end_date)}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -120,6 +120,15 @@ main {
   overflow-x: auto;
 }
 
+.plain-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
 .clients-toolbar {
   display: flex;
   align-items: center;

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -2,6 +2,7 @@ export const dynamic = "force-dynamic";
 
 import { api, DashboardSnapshot } from "../lib/api";
 import { AutomationPanel } from "./components/AutomationPanel";
+import { OperationsPanel } from "./components/OperationsPanel";
 import { MetricCard } from "./components/MetricCard";
 
 async function getDashboard(): Promise<DashboardSnapshot> {
@@ -45,6 +46,7 @@ export default async function DashboardPage(): Promise<JSX.Element> {
           helper="Clients using secure portal"
         />
       </div>
+      <OperationsPanel />
       <AutomationPanel />
     </div>
   );

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -22,6 +22,7 @@ async function request<T>(path: string, options: ApiOptions = {}): Promise<T> {
 
 export const api = {
   dashboard: () => request<DashboardSnapshot>("/dashboard"),
+  operations: () => request<OperationsSnapshot>("/dashboard/operations"),
   automationDigest: () => request<AutomationDigest>("/automation/digest"),
   automationHistory: () => request<AutomationDigest[]>("/automation/digest/history"),
   projects: () => request<Project[]>("/projects"),
@@ -96,6 +97,68 @@ export interface DashboardSnapshot {
     avg_response_time_ms: number;
     failing_checks: number;
   };
+}
+
+export interface CashRunway {
+  total_cash_on_hand: number;
+  monthly_burn_rate: number;
+  runway_days: number | null;
+  outstanding_invoices: number;
+  upcoming_payables: number;
+  collection_rate: number;
+}
+
+export interface OperationsProject {
+  project_id: string;
+  project_name: string;
+  client_name?: string | null;
+  health: string;
+  progress: number;
+  late_tasks: number;
+  next_milestone_title?: string | null;
+  next_milestone_due?: string | null;
+}
+
+export interface CapacityAlert {
+  employee_id: string;
+  employee_name: string;
+  available_hours: number;
+  billable_ratio: number;
+  reason: string;
+}
+
+export interface TimeOffWindow {
+  employee_id: string;
+  employee_name: string;
+  start_date: string;
+  end_date: string;
+  status: string;
+}
+
+export interface MonitoringIncident {
+  site_id: string;
+  site_label: string;
+  severity: string;
+  triggered_at: string;
+  message: string;
+  acknowledged: boolean;
+}
+
+export interface OperationsRecommendation {
+  title: string;
+  description: string;
+  category: string;
+  impact: string;
+}
+
+export interface OperationsSnapshot {
+  generated_at: string;
+  cash: CashRunway;
+  at_risk_projects: OperationsProject[];
+  capacity_alerts: CapacityAlert[];
+  upcoming_time_off: TimeOffWindow[];
+  monitoring_incidents: MonitoringIncident[];
+  recommendations: OperationsRecommendation[];
 }
 
 export type AutomationCategory =


### PR DESCRIPTION
## Summary
- add a compatibility shim for ForwardRef evaluation and expose a new `/dashboard/operations` API backed by fresh operations schemas
- enrich the in-memory dataset with realistic tasks, employees, alerts, and compute a consolidated operations snapshot with recommendations
- surface the snapshot in the Next.js dashboard via a new OperationsPanel component and document the working proof of concept in the README

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68dc2258ca8883338f0ea0c19afe456a