### PR TITLE
feat: add crm overview for client management

### DIFF
--- a/backend/app/api/routes/clients.py
+++ b/backend/app/api/routes/clients.py
@@ -4,6 +4,7 @@ from fastapi import APIRouter, HTTPException, status
 
 from ...schemas.clients import (
     Client,
+    ClientCRMOverview,
     ClientCreateRequest,
     ClientDashboard,
     ClientEngagement,
@@ -29,6 +30,11 @@ def client_summary() -> ClientSummary:
 @router.get("/engagements", response_model=List[ClientEngagement])
 def client_engagements() -> List[ClientEngagement]:
     return store.client_engagements()
+
+
+@router.get("/crm/overview", response_model=ClientCRMOverview)
+def client_crm_overview() -> ClientCRMOverview:
+    return store.client_crm_overview()
 
 
 @router.post("", response_model=ClientWithProjects, status_code=status.HTTP_201_CREATED)

--- a/backend/app/schemas/clients.py
+++ b/backend/app/schemas/clients.py
@@ -229,3 +229,46 @@ class ClientEngagement(BaseModel):
     next_milestone: Optional[Milestone] = None
     last_interaction_at: Optional[datetime] = None
     health: str
+
+
+class CRMMetric(BaseModel):
+    label: str
+    value: float
+    unit: str = ""
+    description: Optional[str] = None
+
+
+class CRMPipelineStage(BaseModel):
+    segment: ClientSegment
+    label: str
+    client_count: int
+    total_active_projects: int
+    total_outstanding_balance: float
+    avg_days_since_touch: Optional[float] = None
+    follow_up_needed: int = 0
+
+
+class CRMInteractionGap(BaseModel):
+    client_id: str
+    organization_name: str
+    segment: ClientSegment
+    preferred_channel: InteractionChannel
+    last_interaction_at: Optional[datetime] = None
+    days_since_last: Optional[int] = None
+    suggested_next_step: str
+
+
+class CRMContactGap(BaseModel):
+    client_id: str
+    organization_name: str
+    segment: ClientSegment
+    contact_count: int
+    recommended_role: str
+
+
+class ClientCRMOverview(BaseModel):
+    generated_at: datetime = Field(default_factory=datetime.utcnow)
+    metrics: List[CRMMetric] = Field(default_factory=list)
+    pipeline: List[CRMPipelineStage] = Field(default_factory=list)
+    interaction_gaps: List[CRMInteractionGap] = Field(default_factory=list)
+    contact_gaps: List[CRMContactGap] = Field(default_factory=list)

--- a/frontend/app/clients/CRMOverview.tsx
+++ b/frontend/app/clients/CRMOverview.tsx
@@ -1,0 +1,215 @@
+import { ClientCRMOverview, ClientSegment } from "../../lib/api";
+
+const currencyFormatter = new Intl.NumberFormat("en-PH", {
+  style: "currency",
+  currency: "PHP",
+  maximumFractionDigits: 0
+});
+
+const numberFormatter = new Intl.NumberFormat("en-US", { maximumFractionDigits: 0 });
+const percentFormatter = new Intl.NumberFormat("en-US", { maximumFractionDigits: 1 });
+
+function formatMetricValue(metric: ClientCRMOverview["metrics"][number]): string {
+  switch (metric.unit) {
+    case "currency":
+      return currencyFormatter.format(metric.value);
+    case "percent":
+      return `${percentFormatter.format(metric.value)}%`;
+    case "days":
+      return `${Math.round(metric.value)} days`;
+    case "accounts":
+      return numberFormatter.format(metric.value);
+    default:
+      return metric.value.toString();
+  }
+}
+
+const segmentLabels: Record<ClientSegment, string> = {
+  retainer: "Retainer",
+  project: "Project",
+  vip: "VIP",
+  prospect: "Prospect"
+};
+
+const segmentBadgeClass: Record<ClientSegment, string> = {
+  retainer: "success",
+  project: "neutral",
+  vip: "warning",
+  prospect: "info"
+};
+
+function formatDays(value?: number | null): string {
+  if (value === null || value === undefined) {
+    return "—";
+  }
+  return `${Math.round(value)} days`;
+}
+
+function formatLastInteraction(days?: number | null): string {
+  if (days === null || days === undefined) {
+    return "No interactions recorded";
+  }
+  if (days <= 0) {
+    return "Touched today";
+  }
+  if (days === 1) {
+    return "1 day ago";
+  }
+  return `${days} days ago`;
+}
+
+function formatChannel(channel: string): string {
+  switch (channel) {
+    case "email":
+      return "Email";
+    case "portal":
+      return "Client portal";
+    case "social":
+      return "Social";
+    case "phone":
+      return "Phone";
+    default:
+      return channel;
+  }
+}
+
+interface CRMOverviewProps {
+  overview: ClientCRMOverview;
+}
+
+export function CRMOverview({ overview }: CRMOverviewProps): JSX.Element {
+  return (
+    <section className="crm-overview" aria-labelledby="crm-overview-title">
+      <h3 id="crm-overview-title" className="sr-only">
+        CRM overview
+      </h3>
+      <div className="crm-metrics" role="list">
+        {overview.metrics.map((metric) => (
+          <article key={metric.label} className="crm-metric-card" role="listitem">
+            <header className="crm-metric-header">
+              <h4>{metric.label}</h4>
+              {metric.description && <p className="crm-metric-description">{metric.description}</p>}
+            </header>
+            <p className="crm-metric-value">{formatMetricValue(metric)}</p>
+          </article>
+        ))}
+      </div>
+
+      <div className="crm-overview-grid">
+        <section className="crm-section crm-section--pipeline" aria-labelledby="crm-pipeline-title">
+          <div className="crm-section-header">
+            <div>
+              <h4 id="crm-pipeline-title">Pipeline health</h4>
+              <p className="crm-section-subtitle">
+                Segment coverage and account velocity grouped by delivery model.
+              </p>
+            </div>
+          </div>
+          <div className="table-scroll">
+            <table className="table crm-pipeline-table">
+              <thead>
+                <tr>
+                  <th scope="col">Stage</th>
+                  <th scope="col">Accounts</th>
+                  <th scope="col">Active projects</th>
+                  <th scope="col">Outstanding</th>
+                  <th scope="col">Avg days since touch</th>
+                  <th scope="col">Follow-ups</th>
+                </tr>
+              </thead>
+              <tbody>
+                {overview.pipeline.map((stage) => (
+                  <tr key={stage.segment}>
+                    <th scope="row">
+                      <div className="crm-pipeline-stage">
+                        <span className={`badge ${segmentBadgeClass[stage.segment]}`}>
+                          {segmentLabels[stage.segment]}
+                        </span>
+                        <span>{stage.label}</span>
+                      </div>
+                    </th>
+                    <td>{numberFormatter.format(stage.client_count)}</td>
+                    <td>{numberFormatter.format(stage.total_active_projects)}</td>
+                    <td>{currencyFormatter.format(stage.total_outstanding_balance)}</td>
+                    <td>{formatDays(stage.avg_days_since_touch)}</td>
+                    <td>
+                      {stage.follow_up_needed > 0 ? (
+                        <span className="crm-followup-highlight">
+                          {numberFormatter.format(stage.follow_up_needed)} need outreach
+                        </span>
+                      ) : (
+                        "All engaged"
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        <section className="crm-section" aria-labelledby="crm-interactions-title">
+          <div className="crm-section-header">
+            <div>
+              <h4 id="crm-interactions-title">Proactive follow-ups</h4>
+              <p className="crm-section-subtitle">
+                Accounts without a touchpoint in the last three weeks automatically surface here.
+              </p>
+            </div>
+          </div>
+          <ul className="crm-gap-list">
+            {overview.interaction_gaps.length === 0 && (
+              <li className="crm-gap-item empty">Every account has been contacted within the last 21 days.</li>
+            )}
+            {overview.interaction_gaps.map((gap) => (
+              <li key={gap.client_id} className="crm-gap-item">
+                <div className="crm-gap-header">
+                  <span className="crm-gap-name">{gap.organization_name}</span>
+                  <span className={`badge ${segmentBadgeClass[gap.segment]}`}>
+                    {segmentLabels[gap.segment]}
+                  </span>
+                </div>
+                <div className="crm-gap-meta">
+                  <span>{formatLastInteraction(gap.days_since_last)}</span>
+                  <span>Prefers {formatChannel(gap.preferred_channel)}</span>
+                </div>
+                <p className="crm-gap-action">{gap.suggested_next_step}</p>
+              </li>
+            ))}
+          </ul>
+        </section>
+
+        <section className="crm-section" aria-labelledby="crm-contacts-title">
+          <div className="crm-section-header">
+            <div>
+              <h4 id="crm-contacts-title">Contact coverage gaps</h4>
+              <p className="crm-section-subtitle">
+                Ensure every account has buying committee stakeholders documented.
+              </p>
+            </div>
+          </div>
+          <ul className="crm-gap-list">
+            {overview.contact_gaps.length === 0 && (
+              <li className="crm-gap-item empty">Contact coverage looks great across all clients.</li>
+            )}
+            {overview.contact_gaps.map((gap) => (
+              <li key={gap.client_id} className="crm-gap-item">
+                <div className="crm-gap-header">
+                  <span className="crm-gap-name">{gap.organization_name}</span>
+                  <span className={`badge ${segmentBadgeClass[gap.segment]}`}>
+                    {segmentLabels[gap.segment]}
+                  </span>
+                </div>
+                <div className="crm-gap-meta">
+                  <span>{numberFormatter.format(gap.contact_count)} contacts</span>
+                </div>
+                <p className="crm-gap-action">Add a {gap.recommended_role.toLowerCase()} to strengthen engagement.</p>
+              </li>
+            ))}
+          </ul>
+        </section>
+      </div>
+    </section>
+  );
+}
+

--- a/frontend/app/clients/page.tsx
+++ b/frontend/app/clients/page.tsx
@@ -1,22 +1,28 @@
 export const dynamic = "force-dynamic";
 
-import { api, Client } from "../../lib/api";
+import { api, Client, ClientCRMOverview } from "../../lib/api";
 import { ClientsTable } from "./ClientsTable";
+import { CRMOverview } from "./CRMOverview";
 
 async function getClients(): Promise<Client[]> {
   return api.clients();
 }
 
+async function getCrmOverview(): Promise<ClientCRMOverview> {
+  return api.clientCRMOverview();
+}
+
 export default async function ClientsPage(): Promise<JSX.Element> {
-  const clients = await getClients();
+  const [clients, overview] = await Promise.all([getClients(), getCrmOverview()]);
 
   return (
-    <div>
-      <h2 className="section-title">Client Intelligence</h2>
-      <p className="text-muted" style={{ maxWidth: "680px" }}>
-        Every account centralizes contacts, documents, and preferred communication channels to power proactive service across the
-        two brands.
+    <div className="crm-page">
+      <h2 className="section-title">Client Relationship Hub</h2>
+      <p className="text-muted" style={{ maxWidth: "760px" }}>
+        Stay ahead of renewals and relationship risks with CRM-grade visibility across every account. Segment pipelines, prioritize
+        outreach, and confirm that executive sponsors have the coverage they expect.
       </p>
+      <CRMOverview overview={overview} />
       <ClientsTable clients={clients} />
     </div>
   );

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -93,6 +93,16 @@ main {
   color: #b91c1c;
 }
 
+.badge.info {
+  background: rgba(191, 219, 254, 0.7);
+  color: #1d4ed8;
+}
+
+.badge.neutral {
+  background: rgba(226, 232, 240, 0.85);
+  color: #334155;
+}
+
 .section-title {
   font-size: 1.75rem;
   margin-bottom: 1rem;
@@ -132,8 +142,43 @@ main {
 .clients-toolbar {
   display: flex;
   align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
   gap: 1rem;
-  margin-bottom: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.clients-toolbar-actions {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.clients-toolbar-filters {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.clients-toolbar-filters input,
+.clients-toolbar-filters select {
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  padding: 0.5rem 0.9rem;
+  background: rgba(255, 255, 255, 0.85);
+  color: #1f2937;
+}
+
+.clients-toolbar-filters button {
+  padding: 0.45rem 0.9rem;
+}
+
+.button:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+  box-shadow: none;
+  transform: none;
 }
 
 .button {
@@ -478,6 +523,231 @@ main {
   font-weight: 600;
   background: rgba(148, 163, 184, 0.3);
   color: #475569;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.crm-page {
+  display: flex;
+  flex-direction: column;
+  gap: 2.5rem;
+}
+
+.crm-overview {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  margin-top: 1.5rem;
+}
+
+.crm-metrics {
+  display: grid;
+  gap: 1rem;
+}
+
+@media (min-width: 768px) {
+  .crm-metrics {
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  }
+}
+
+.crm-metric-card {
+  background: rgba(255, 255, 255, 0.92);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 1rem;
+  padding: 1.25rem;
+  box-shadow: 0 20px 40px rgba(148, 163, 184, 0.15);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.crm-metric-header h4 {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: #1f2937;
+}
+
+.crm-metric-description {
+  margin: 0;
+  font-size: 0.85rem;
+  color: #64748b;
+}
+
+.crm-metric-value {
+  font-size: 1.65rem;
+  font-weight: 700;
+  color: #4338ca;
+}
+
+.crm-overview-grid {
+  display: grid;
+  gap: 1.75rem;
+}
+
+@media (min-width: 1024px) {
+  .crm-overview-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .crm-section--pipeline {
+    grid-column: span 2;
+  }
+}
+
+.crm-section {
+  background: rgba(255, 255, 255, 0.92);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 1rem;
+  padding: 1.25rem;
+  box-shadow: 0 18px 32px rgba(148, 163, 184, 0.14);
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.crm-section-header h4 {
+  margin: 0 0 0.35rem;
+  font-size: 1.1rem;
+}
+
+.crm-section-subtitle {
+  margin: 0;
+  font-size: 0.85rem;
+  color: #64748b;
+}
+
+.crm-pipeline-table td,
+.crm-pipeline-table th {
+  font-size: 0.9rem;
+}
+
+.crm-pipeline-stage {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.crm-followup-highlight {
+  display: inline-flex;
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.75rem;
+  background: rgba(250, 204, 21, 0.15);
+  color: #92400e;
+  font-weight: 600;
+}
+
+.crm-gap-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 1rem;
+}
+
+.crm-gap-item {
+  background: rgba(248, 250, 252, 0.9);
+  border-radius: 0.85rem;
+  border: 1px solid rgba(203, 213, 225, 0.6);
+  padding: 0.9rem 1rem;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.crm-gap-item.empty {
+  text-align: center;
+  color: #64748b;
+  font-size: 0.9rem;
+  border-style: dashed;
+}
+
+.crm-gap-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.crm-gap-name {
+  font-weight: 600;
+  color: #1f2937;
+}
+
+.crm-gap-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  font-size: 0.85rem;
+  color: #475569;
+}
+
+.crm-gap-action {
+  margin: 0;
+  font-size: 0.9rem;
+  color: #4338ca;
+  font-weight: 500;
+}
+
+.crm-org-meta {
+  font-size: 0.8rem;
+  color: #64748b;
+  margin-top: 0.35rem;
+}
+
+.crm-contact-cell {
+  display: grid;
+  gap: 0.25rem;
+}
+
+.crm-contact-cell.empty {
+  color: #b91c1c;
+  font-weight: 500;
+}
+
+.crm-contact-count {
+  font-weight: 600;
+  color: #1f2937;
+}
+
+.crm-contact-primary {
+  font-size: 0.85rem;
+  color: #475569;
+}
+
+.crm-last-touch {
+  font-weight: 600;
+  color: #475569;
+}
+
+.crm-last-touch.fresh {
+  color: #047857;
+}
+
+.crm-last-touch.stale {
+  color: #b91c1c;
+}
+
+.crm-result-count {
+  font-size: 0.85rem;
+  color: #475569;
+  font-weight: 500;
+}
+
+.table-empty {
+  text-align: center;
+  padding: 2rem 1rem;
+  color: #64748b;
+  font-size: 0.95rem;
 }
 
 .calendar-task.status-in_progress {

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -41,6 +41,7 @@ export const api = {
   clients: () => request<Client[]>("/clients"),
   client: (clientId: string) => request<Client>(`/clients/${clientId}`),
   clientDashboard: (clientId: string) => request<ClientDashboard>(`/clients/${clientId}/dashboard`),
+  clientCRMOverview: () => request<ClientCRMOverview>("/clients/crm/overview"),
   createClient: (payload: ClientCreateRequest) =>
     request<ClientWithProjects>("/clients", {
       method: "POST",
@@ -449,6 +450,49 @@ export interface ClientDashboard {
   projects: ClientProjectDigest[];
   financials: ClientFinancialSnapshot;
   support: ClientSupportSnapshot;
+}
+
+export interface CRMMetric {
+  label: string;
+  value: number;
+  unit: "" | "accounts" | "currency" | "percent" | "days";
+  description?: string | null;
+}
+
+export interface CRMPipelineStage {
+  segment: ClientSegment;
+  label: string;
+  client_count: number;
+  total_active_projects: number;
+  total_outstanding_balance: number;
+  avg_days_since_touch?: number | null;
+  follow_up_needed: number;
+}
+
+export interface CRMInteractionGap {
+  client_id: string;
+  organization_name: string;
+  segment: ClientSegment;
+  preferred_channel: InteractionChannel;
+  last_interaction_at?: string | null;
+  days_since_last?: number | null;
+  suggested_next_step: string;
+}
+
+export interface CRMContactGap {
+  client_id: string;
+  organization_name: string;
+  segment: ClientSegment;
+  contact_count: number;
+  recommended_role: string;
+}
+
+export interface ClientCRMOverview {
+  generated_at: string;
+  metrics: CRMMetric[];
+  pipeline: CRMPipelineStage[];
+  interaction_gaps: CRMInteractionGap[];
+  contact_gaps: CRMContactGap[];
 }
 
 export interface ProjectSetup {


### PR DESCRIPTION
## Summary
- add a CRM overview endpoint that aggregates client metrics, pipeline health, interaction gaps, and contact coverage
- expose the CRM overview in the Next.js clients area with a new dashboard component and richer table filtering
- refresh portal styling with CRM-focused badges, layouts, and result indicators for relationship monitoring

## Testing
- pytest
- npm run lint
- npm run typecheck *(fails: existing type errors in app/projects/ProjectsDashboard.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68dc56b005a88333a735bf8b8f49c48c