### PR TITLE
Restyle portal UI with warm color palette

### DIFF
--- a/frontend/app/automation/page.tsx
+++ b/frontend/app/automation/page.tsx
@@ -32,7 +32,7 @@ export default async function AutomationHistoryPage(): Promise<JSX.Element> {
         <tbody>
           {history.length === 0 ? (
             <tr>
-              <td colSpan={4} style={{ textAlign: "center", color: "#64748b" }}>
+              <td colSpan={4} style={{ textAlign: "center", color: "#8c6f63" }}>
                 No automation history recorded yet.
               </td>
             </tr>

--- a/frontend/app/components/AutomationPanel.tsx
+++ b/frontend/app/components/AutomationPanel.tsx
@@ -73,7 +73,7 @@ export async function AutomationPanel(): Promise<JSX.Element> {
             surface the next best actions across teams with deep links and suggested owners.
           </p>
         </div>
-        <Link href="/automation" style={{ color: "#6366f1", fontWeight: 600 }}>
+        <Link href="/automation" style={{ color: "#8b3921", fontWeight: 600, textDecoration: "none" }}>
           View full history →
         </Link>
       </div>
@@ -94,7 +94,7 @@ export async function AutomationPanel(): Promise<JSX.Element> {
                   justifyContent: "space-between",
                   alignItems: "flex-start",
                   gap: "1rem",
-                  borderBottom: "1px solid rgba(148,163,184,0.2)",
+                  borderBottom: "1px solid rgba(139,57,33,0.16)",
                   paddingBottom: "1rem"
                 }}
               >
@@ -105,8 +105,8 @@ export async function AutomationPanel(): Promise<JSX.Element> {
                     </span>
                     <span style={{ fontWeight: 600 }}>{task.summary}</span>
                   </div>
-                  {task.details && <p style={{ margin: 0, color: "#64748b" }}>{task.details}</p>}
-                  <div style={{ display: "flex", gap: "1.5rem", flexWrap: "wrap", fontSize: "0.85rem", color: "#64748b" }}>
+                  {task.details && <p style={{ margin: 0, color: "#8c6f63" }}>{task.details}</p>}
+                  <div style={{ display: "flex", gap: "1.5rem", flexWrap: "wrap", fontSize: "0.85rem", color: "#8c6f63" }}>
                     <span style={{ textTransform: "capitalize" }}>{task.category}</span>
                     {dueLabel && <span>{dueLabel}</span>}
                     {task.suggested_assignee && <span>Suggested: {task.suggested_assignee}</span>}
@@ -120,11 +120,12 @@ export async function AutomationPanel(): Promise<JSX.Element> {
                     gap: "0.5rem",
                     padding: "0.65rem 1rem",
                     borderRadius: "0.75rem",
-                    border: "1px solid rgba(129,140,248,0.4)",
-                    color: "#6366f1",
+                    border: "1px solid rgba(139,57,33,0.35)",
+                    color: "#8b3921",
                     fontWeight: 600,
                     textDecoration: "none",
-                    background: "rgba(255,255,255,0.6)"
+                    background: "rgba(247,234,218,0.65)",
+                    boxShadow: "0 8px 18px rgba(139,57,33,0.12)"
                   }}
                 >
                   {task.action_label ?? "Open module"}

--- a/frontend/app/components/MetricCard.tsx
+++ b/frontend/app/components/MetricCard.tsx
@@ -6,10 +6,10 @@ interface MetricCardProps {
 }
 
 const toneColors: Record<NonNullable<MetricCardProps["tone"]>, string> = {
-  default: "#4338ca",
-  success: "#16a34a",
-  warning: "#d97706",
-  danger: "#dc2626"
+  default: "#8b3921",
+  success: "#2f7d4f",
+  warning: "#c1611a",
+  danger: "#b3321b"
 };
 
 export function MetricCard({ title, value, helper, tone = "default" }: MetricCardProps): JSX.Element {
@@ -18,8 +18,8 @@ export function MetricCard({ title, value, helper, tone = "default" }: MetricCar
       <p className="text-muted" style={{ margin: 0, textTransform: "uppercase", letterSpacing: "0.08em", fontSize: "0.75rem" }}>
         {title}
       </p>
-      <p style={{ fontSize: "2rem", margin: "0.25rem 0", color: toneColors[tone] }}>{value}</p>
-      {helper && <p style={{ margin: 0, color: "#64748b", fontSize: "0.85rem" }}>{helper}</p>}
+      <p style={{ fontSize: "2.15rem", margin: "0.35rem 0", color: toneColors[tone], fontWeight: 600 }}>{value}</p>
+      {helper && <p style={{ margin: 0, color: "#8c6f63", fontSize: "0.85rem" }}>{helper}</p>}
     </div>
   );
 }

--- a/frontend/app/components/OperationsPanel.tsx
+++ b/frontend/app/components/OperationsPanel.tsx
@@ -155,7 +155,7 @@ export async function OperationsPanel(): Promise<JSX.Element> {
                       </span>
                     </div>
                     <p className="text-muted" style={{ margin: 0 }}>{incident.message}</p>
-                    <span style={{ fontSize: "0.8rem", color: "#94a3b8" }}>
+                    <span style={{ fontSize: "0.8rem", color: "#b08977" }}>
                       Triggered {new Date(incident.triggered_at).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}
                     </span>
                   </li>

--- a/frontend/app/components/Sidebar.tsx
+++ b/frontend/app/components/Sidebar.tsx
@@ -24,8 +24,8 @@ export function Sidebar(): JSX.Element {
     <aside
       style={{
         width: "240px",
-        background: "linear-gradient(180deg, rgba(237, 233, 254, 0.95), rgba(255, 247, 237, 0.95))",
-        borderRight: "1px solid rgba(196, 181, 253, 0.45)",
+        background: "linear-gradient(180deg, rgba(139, 57, 33, 0.95), rgba(139, 57, 33, 0.78))",
+        borderRight: "1px solid rgba(63, 34, 22, 0.25)",
         display: "flex",
         flexDirection: "column",
         padding: "1.5rem 1rem",
@@ -33,10 +33,10 @@ export function Sidebar(): JSX.Element {
       }}
     >
       <div>
-        <p style={{ fontSize: "0.75rem", textTransform: "uppercase", color: "#64748b", marginBottom: "0.25rem" }}>
+        <p style={{ fontSize: "0.75rem", textTransform: "uppercase", color: "#f2d5c1", letterSpacing: "0.12em", marginBottom: "0.25rem" }}>
           Disenyorita & Isla
         </p>
-        <h1 style={{ fontSize: "1.25rem", margin: 0 }}>Command Center</h1>
+        <h1 style={{ fontSize: "1.35rem", margin: 0, color: "#fef9f6" }}>Command Center</h1>
       </div>
       <nav style={{ display: "flex", flexDirection: "column", gap: "0.5rem" }}>
         {navItems.map((item) => (
@@ -49,21 +49,20 @@ export function Sidebar(): JSX.Element {
             style={{
               padding: "0.75rem 1rem",
               borderRadius: "0.75rem",
-              color: pathname === item.href ? "#312e81" : "#475569",
-              backgroundColor: pathname === item.href
-                ? "rgba(196, 181, 253, 0.6)"
-                : "transparent",
+              color: pathname === item.href ? "#8b3921" : "#fdece0",
+              backgroundColor: pathname === item.href ? "#f7eada" : "rgba(255, 255, 255, 0.08)",
               textDecoration: "none",
               fontWeight: 600,
               transition: "all 0.2s ease",
-              border: pathname === item.href ? "1px solid rgba(99, 102, 241, 0.4)" : "1px solid transparent"
+              border: pathname === item.href ? "1px solid rgba(139, 57, 33, 0.35)" : "1px solid transparent",
+              backdropFilter: pathname === item.href ? "blur(2px)" : undefined
             }}
           >
             {item.label}
           </Link>
         ))}
       </nav>
-      <div style={{ marginTop: "auto", fontSize: "0.75rem", color: "#64748b" }}>
+      <div style={{ marginTop: "auto", fontSize: "0.75rem", color: "#f7dccc", lineHeight: 1.4 }}>
         <p style={{ margin: 0 }}>Secure multi-tenant workspace.</p>
         <p style={{ margin: 0 }}>MFA & RBAC enforced.</p>
       </div>

--- a/frontend/app/components/TopBar.tsx
+++ b/frontend/app/components/TopBar.tsx
@@ -11,31 +11,32 @@ export function TopBar(): JSX.Element {
         display: "flex",
         justifyContent: "space-between",
         alignItems: "center",
-        padding: "1.5rem 2rem",
-        borderBottom: "1px solid rgba(196, 181, 253, 0.35)",
-        background: "rgba(255, 255, 255, 0.82)",
-        backdropFilter: "blur(14px)",
+        padding: "1.75rem 2.5rem",
+        borderBottom: "1px solid rgba(139, 57, 33, 0.18)",
+        background: "linear-gradient(90deg, rgba(255, 248, 241, 0.92), rgba(255, 255, 255, 0.76))",
+        backdropFilter: "blur(16px)",
         position: "sticky",
         top: 0,
         zIndex: 10
       }}
     >
       <div>
-        <h2 style={{ margin: 0, fontSize: "1.5rem" }}>Unified Operations</h2>
-        <p style={{ margin: 0, color: "#64748b", fontSize: "0.875rem" }}>Real-time overview for Disenyorita & Isla</p>
+        <h2 style={{ margin: 0, fontSize: "1.6rem", color: "#8b3921" }}>Unified Operations</h2>
+        <p style={{ margin: 0, color: "#8c6f63", fontSize: "0.9rem" }}>Real-time overview for Disenyorita & Isla</p>
       </div>
       <div style={{ display: "flex", alignItems: "center", gap: "1.5rem" }}>
-        <span style={{ fontSize: "0.875rem", color: "#475569" }}>{now}</span>
+        <span style={{ fontSize: "0.9rem", color: "#6f4d3d", fontWeight: 500 }}>{now}</span>
         <div
           style={{
             display: "flex",
             gap: "0.5rem",
-            background: "rgba(129, 140, 248, 0.18)",
+            background: "rgba(139, 57, 33, 0.1)",
             borderRadius: "9999px",
-            padding: "0.35rem 0.75rem",
-            fontSize: "0.75rem",
-            color: "#6366f1",
-            fontWeight: 600
+            padding: "0.45rem 0.85rem",
+            fontSize: "0.78rem",
+            color: "#8b3921",
+            fontWeight: 600,
+            letterSpacing: "0.08em"
           }}
         >
           <span>RBAC</span>

--- a/frontend/app/financials/page.tsx
+++ b/frontend/app/financials/page.tsx
@@ -129,10 +129,10 @@ export default async function FinancialsPage(): Promise<JSX.Element> {
                 <td>{formatCurrency(record.total_invoiced, record.currency)}</td>
                 <td>{formatCurrency(record.total_collected, record.currency)}</td>
                 <td>{formatCurrency(record.total_expenses, record.currency)}</td>
-                <td style={{ color: record.outstanding_amount > 0 ? "#fcd34d" : "#64748b" }}>
+                <td style={{ color: record.outstanding_amount > 0 ? "#d4a017" : "#8c6f63" }}>
                   {formatCurrency(record.outstanding_amount, record.currency)}
                 </td>
-                <td style={{ color: record.net_revenue >= 0 ? "#16a34a" : "#fb7185" }}>
+                <td style={{ color: record.net_revenue >= 0 ? "#2f7d4f" : "#b3321b" }}>
                   {formatCurrency(record.net_revenue, record.currency)}
                 </td>
               </tr>
@@ -176,7 +176,7 @@ export default async function FinancialsPage(): Promise<JSX.Element> {
                     <Link
                       href={reminderTasks.get(invoice.id)!.url}
                       style={{
-                        color: "#6366f1",
+                        color: "#8b3921",
                         textDecoration: "none",
                         fontWeight: 600
                       }}
@@ -184,7 +184,7 @@ export default async function FinancialsPage(): Promise<JSX.Element> {
                       {reminderTasks.get(invoice.id)!.label}
                     </Link>
                   ) : (
-                    <span style={{ color: "#64748b" }}>—</span>
+                    <span style={{ color: "#8c6f63" }}>—</span>
                   )}
                 </td>
               </tr>
@@ -213,7 +213,7 @@ export default async function FinancialsPage(): Promise<JSX.Element> {
           <tbody>
             {pricingSuggestions.length === 0 ? (
               <tr>
-                <td colSpan={6} style={{ textAlign: "center", color: "#64748b" }}>
+                <td colSpan={6} style={{ textAlign: "center", color: "#8c6f63" }}>
                   No pricing suggestions available yet. Add financial data to generate insights.
                 </td>
               </tr>
@@ -244,7 +244,7 @@ export default async function FinancialsPage(): Promise<JSX.Element> {
             display: "inline-flex",
             alignItems: "center",
             gap: "0.5rem",
-            color: "#6366f1",
+            color: "#8b3921",
             fontWeight: 600,
             textDecoration: "none"
           }}

--- a/frontend/app/financials/tax-calculator/page.tsx
+++ b/frontend/app/financials/tax-calculator/page.tsx
@@ -88,31 +88,31 @@ function describeDueDate(value: string): { label: string; color: string } {
     const overdue = Math.abs(diffDays);
     return {
       label: `Overdue by ${overdue} day${overdue === 1 ? "" : "s"}`,
-      color: "#fb7185"
+      color: "#b3321b"
     };
   }
 
   if (diffDays === 0) {
-    return { label: "Due today", color: "#f97316" };
+    return { label: "Due today", color: "#c1611a" };
   }
 
   if (diffDays <= 14) {
     return {
       label: `Due in ${diffDays} day${diffDays === 1 ? "" : "s"}`,
-      color: "#f97316"
+      color: "#c1611a"
     };
   }
 
   if (diffDays <= 45) {
     return {
       label: `Due in ${diffDays} days`,
-      color: "#facc15"
+      color: "#d4a017"
     };
   }
 
   return {
     label: `Due in ${diffDays} days`,
-    color: "#22c55e"
+    color: "#2f7d4f"
   };
 }
 
@@ -149,9 +149,9 @@ function EntryList({
             style={{
               padding: "0.75rem",
               borderRadius: "0.75rem",
-              border: "1px solid rgba(148,163,184,0.45)",
-              background: "rgba(255,255,255,0.9)",
-              color: "#1f2937"
+              border: "1px solid rgba(139,57,33,0.28)",
+              background: "rgba(255,255,255,0.92)",
+              color: "#3f2216"
             }}
           />
           <input
@@ -162,9 +162,9 @@ function EntryList({
             style={{
               padding: "0.75rem",
               borderRadius: "0.75rem",
-              border: "1px solid rgba(148,163,184,0.45)",
-              background: "rgba(255,255,255,0.9)",
-              color: "#1f2937"
+                border: "1px solid rgba(139,57,33,0.28)",
+                background: "rgba(255,255,255,0.92)",
+                color: "#3f2216"
             }}
           />
           <button
@@ -174,7 +174,7 @@ function EntryList({
             style={{
               border: "none",
               background: "transparent",
-              color: "#cbd5f5",
+              color: "#f2d5c1",
               fontSize: "1.25rem",
               cursor: "pointer"
             }}
@@ -189,11 +189,12 @@ function EntryList({
         style={{
           padding: "0.75rem 1rem",
           borderRadius: "0.75rem",
-          border: "1px solid rgba(129,140,248,0.4)",
-          background: "rgba(255,255,255,0.6)",
-          color: "#6366f1",
+          border: "1px solid rgba(139,57,33,0.35)",
+          background: "rgba(247,234,218,0.85)",
+          color: "#8b3921",
           fontWeight: 600,
-          cursor: "pointer"
+          cursor: "pointer",
+          boxShadow: "0 10px 20px rgba(139,57,33,0.12)"
         }}
       >
         + Add entry
@@ -329,7 +330,7 @@ export default function TaxCalculatorPage(): JSX.Element {
 
   return (
     <div>
-      <Link href="/financials" style={{ color: "#6366f1", textDecoration: "none", fontWeight: 600 }}>
+      <Link href="/financials" style={{ color: "#8b3921", textDecoration: "none", fontWeight: 600 }}>
         ← Back to financial control
       </Link>
       <h2 className="section-title" style={{ marginTop: "1.5rem" }}>
@@ -375,7 +376,7 @@ export default function TaxCalculatorPage(): JSX.Element {
             </div>
           </div>
           {businessProfile.filing_frequencies.length > 0 && (
-            <ul style={{ margin: 0, paddingLeft: "1.25rem", color: "#475569" }}>
+            <ul style={{ margin: 0, paddingLeft: "1.25rem", color: "#6f4d3d" }}>
               {businessProfile.filing_frequencies.map((item) => (
                 <li key={item} style={{ marginBottom: "0.25rem" }}>
                   {item}
@@ -391,11 +392,11 @@ export default function TaxCalculatorPage(): JSX.Element {
                 gap: "0.5rem",
                 padding: "0.75rem 1rem",
                 borderRadius: "0.75rem",
-                background: "rgba(99, 102, 241, 0.08)",
+                background: "rgba(139, 57, 33, 0.12)",
               }}
             >
-              <strong style={{ color: "#312e81", fontSize: "0.9rem" }}>Compliance reminders</strong>
-              <ul style={{ margin: 0, paddingLeft: "1.25rem", color: "#3730a3" }}>
+              <strong style={{ color: "#8b3921", fontSize: "0.9rem" }}>Compliance reminders</strong>
+              <ul style={{ margin: 0, paddingLeft: "1.25rem", color: "#6f4d3d" }}>
                 {businessProfile.compliance_notes.map((note) => (
                   <li key={note} style={{ marginBottom: "0.25rem" }}>
                     {note}
@@ -429,8 +430,8 @@ export default function TaxCalculatorPage(): JSX.Element {
                     gap: "0.25rem",
                     padding: "0.75rem 1rem",
                     borderRadius: "0.75rem",
-                    border: "1px solid rgba(148,163,184,0.35)",
-                    background: "rgba(255,255,255,0.7)"
+                    border: "1px solid rgba(139,57,33,0.18)",
+                    background: "rgba(247,234,218,0.7)"
                   }}
                 >
                   <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: "1rem" }}>
@@ -522,9 +523,9 @@ export default function TaxCalculatorPage(): JSX.Element {
               style={{
                 padding: "0.75rem",
                 borderRadius: "0.75rem",
-                border: "1px solid rgba(148,163,184,0.45)",
-                background: "rgba(255,255,255,0.9)",
-                color: "#1f2937"
+                border: "1px solid rgba(139,57,33,0.28)",
+                background: "rgba(255,255,255,0.92)",
+                color: "#3f2216"
               }}
             >
               <option value={1}>1% (CREATE relief for MSMEs)</option>
@@ -546,17 +547,17 @@ export default function TaxCalculatorPage(): JSX.Element {
             borderRadius: "0.75rem",
             border: "none",
             background: loading
-              ? "rgba(203, 213, 225, 0.7)"
-              : "linear-gradient(135deg, #a5b4fc, #fbcfe8)",
-            color: loading ? "#475569" : "#312e81",
+              ? "rgba(191, 171, 157, 0.5)"
+              : "linear-gradient(135deg, #8b3921, #c0694d)",
+            color: loading ? "#7c5c4b" : "#fffaf5",
             fontWeight: 700,
             cursor: loading ? "not-allowed" : "pointer",
-            boxShadow: loading ? "none" : "0 16px 32px rgba(165, 180, 252, 0.35)"
+            boxShadow: loading ? "none" : "0 18px 34px rgba(139, 57, 33, 0.35)"
           }}
         >
           {loading ? "Calculating…" : "Recalculate tax obligations"}
         </button>
-        {error && <p style={{ color: "#fb7185", margin: 0 }}>{error}</p>}
+        {error && <p style={{ color: "#b3321b", margin: 0 }}>{error}</p>}
       </div>
 
       <div className="card" style={{ marginTop: "2.5rem", display: "flex", flexDirection: "column", gap: "1rem" }}>
@@ -568,11 +569,11 @@ export default function TaxCalculatorPage(): JSX.Element {
           </div>
           <div>
             <p className="text-muted" style={{ margin: 0 }}>Total expenses</p>
-            <p style={{ fontSize: "1.4rem", margin: "0.25rem 0", color: "#fb7185" }}>{formatCurrency(totalExpenses)}</p>
+            <p style={{ fontSize: "1.4rem", margin: "0.25rem 0", color: "#b3321b" }}>{formatCurrency(totalExpenses)}</p>
           </div>
           <div>
             <p className="text-muted" style={{ margin: 0 }}>Allowable deductions</p>
-            <p style={{ fontSize: "1.4rem", margin: "0.25rem 0", color: "#fcd34d" }}>{formatCurrency(totalDeductions)}</p>
+            <p style={{ fontSize: "1.4rem", margin: "0.25rem 0", color: "#d4a017" }}>{formatCurrency(totalDeductions)}</p>
           </div>
           <div>
             <p className="text-muted" style={{ margin: 0 }}>Projected taxable income</p>
@@ -587,30 +588,30 @@ export default function TaxCalculatorPage(): JSX.Element {
         <div className="card" style={{ marginTop: "2.5rem", display: "flex", flexDirection: "column", gap: "0.75rem" }}>
           <h3 style={{ margin: 0 }}>Automated tax breakdown</h3>
           <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(200px, 1fr))", gap: "1rem" }}>
-            <div>
-              <p className="text-muted" style={{ margin: 0 }}>Income tax</p>
-              <p style={{ fontSize: "1.5rem", margin: "0.25rem 0", color: "#fb7185" }}>
-                {formatCurrency(calculation.income_tax)}
-              </p>
-            </div>
-            <div>
-              <p className="text-muted" style={{ margin: 0 }}>Percentage tax</p>
-              <p style={{ fontSize: "1.5rem", margin: "0.25rem 0", color: "#fcd34d" }}>
-                {formatCurrency(calculation.percentage_tax)}
-              </p>
-            </div>
-            <div>
-              <p className="text-muted" style={{ margin: 0 }}>VAT due</p>
-              <p style={{ fontSize: "1.5rem", margin: "0.25rem 0", color: "#60a5fa" }}>
-                {formatCurrency(calculation.vat_due)}
-              </p>
-            </div>
-            <div>
-              <p className="text-muted" style={{ margin: 0 }}>Total estimated tax</p>
-              <p style={{ fontSize: "1.5rem", margin: "0.25rem 0", color: "#fb7185" }}>
-                {formatCurrency(calculation.total_tax)}
-              </p>
-            </div>
+          <div>
+            <p className="text-muted" style={{ margin: 0 }}>Income tax</p>
+            <p style={{ fontSize: "1.5rem", margin: "0.25rem 0", color: "#b3321b" }}>
+              {formatCurrency(calculation.income_tax)}
+            </p>
+          </div>
+          <div>
+            <p className="text-muted" style={{ margin: 0 }}>Percentage tax</p>
+            <p style={{ fontSize: "1.5rem", margin: "0.25rem 0", color: "#d4a017" }}>
+              {formatCurrency(calculation.percentage_tax)}
+            </p>
+          </div>
+          <div>
+            <p className="text-muted" style={{ margin: 0 }}>VAT due</p>
+            <p style={{ fontSize: "1.5rem", margin: "0.25rem 0", color: "#2f7d4f" }}>
+              {formatCurrency(calculation.vat_due)}
+            </p>
+          </div>
+          <div>
+            <p className="text-muted" style={{ margin: 0 }}>Total estimated tax</p>
+            <p style={{ fontSize: "1.5rem", margin: "0.25rem 0", color: "#8b3921" }}>
+              {formatCurrency(calculation.total_tax)}
+            </p>
+          </div>
             <div>
               <p className="text-muted" style={{ margin: 0 }}>Effective tax rate</p>
               <p style={{ fontSize: "1.5rem", margin: "0.25rem 0" }}>{calculation.effective_tax_rate.toFixed(2)}%</p>
@@ -635,7 +636,7 @@ export default function TaxCalculatorPage(): JSX.Element {
                 <strong style={{ textTransform: "uppercase", letterSpacing: "0.05em", fontSize: "0.75rem" }}>
                   {tip.category}
                 </strong>
-                <p style={{ margin: "0.25rem 0 0", color: "#64748b" }}>{tip.message}</p>
+                <p style={{ margin: "0.25rem 0 0", color: "#8c6f63" }}>{tip.message}</p>
               </li>
             ))}
           </ul>

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -1,7 +1,19 @@
 :root {
   color-scheme: light;
   font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-  background-color: #f5f3ff;
+  background-color: #f7eada;
+  --color-primary: #8b3921;
+  --color-primary-dark: #682817;
+  --color-secondary: #f7eada;
+  --color-accent: #c0694d;
+  --color-surface: #fff8f1;
+  --color-surface-strong: #ffffff;
+  --color-ink: #3f2216;
+  --color-muted: #8c6f63;
+  --color-border: rgba(139, 57, 33, 0.2);
+  --color-border-strong: rgba(139, 57, 33, 0.35);
+  --shadow-soft: 0 18px 32px rgba(139, 57, 33, 0.12);
+  --shadow-strong: 0 22px 60px rgba(68, 30, 18, 0.18);
 }
 
 * {
@@ -10,8 +22,8 @@
 
 body {
   margin: 0;
-  background: linear-gradient(160deg, #f5f3ff 0%, #fef6f9 100%);
-  color: #334155;
+  background: radial-gradient(circle at top left, #fff2e5 0%, var(--color-secondary) 38%, #f1d4c6 100%);
+  color: var(--color-ink);
 }
 
 main {
@@ -24,7 +36,8 @@ main {
 }
 
 .content-area {
-  padding: 2rem;
+  padding: 2.5rem clamp(1.5rem, 5vw, 3.25rem);
+  background: linear-gradient(180deg, rgba(255, 248, 241, 0.88), rgba(255, 255, 255, 0.82));
 }
 
 .card-grid {
@@ -39,11 +52,18 @@ main {
 }
 
 .card {
-  background: rgba(255, 255, 255, 0.92);
-  border: 1px solid rgba(148, 163, 184, 0.25);
-  border-radius: 1rem;
-  padding: 1.5rem;
-  box-shadow: 0 12px 30px rgba(148, 163, 184, 0.18);
+  background: linear-gradient(160deg, var(--color-surface) 0%, rgba(255, 255, 255, 0.9) 100%);
+  border: 1px solid var(--color-border);
+  border-radius: 1.15rem;
+  padding: 1.75rem;
+  box-shadow: var(--shadow-soft);
+  backdrop-filter: blur(6px);
+  transition: transform 0.18s ease, box-shadow 0.18s ease;
+}
+
+.card:hover {
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-strong);
 }
 
 .card h3 {
@@ -53,7 +73,7 @@ main {
 }
 
 .text-muted {
-  color: #64748b;
+  color: var(--color-muted);
 }
 
 .table {
@@ -66,7 +86,7 @@ main {
 .table td {
   padding: 0.75rem 1rem;
   text-align: left;
-  border-bottom: 1px solid rgba(148, 163, 184, 0.18);
+  border-bottom: 1px solid rgba(139, 57, 33, 0.1);
 }
 
 .badge {
@@ -79,28 +99,28 @@ main {
 }
 
 .badge.success {
-  background: rgba(187, 247, 208, 0.7);
-  color: #15803d;
+  background: rgba(70, 137, 102, 0.12);
+  color: #2f7d4f;
 }
 
 .badge.warning {
-  background: rgba(254, 243, 199, 0.7);
-  color: #b45309;
+  background: rgba(192, 97, 26, 0.12);
+  color: #c1611a;
 }
 
 .badge.danger {
-  background: rgba(254, 202, 202, 0.7);
-  color: #b91c1c;
+  background: rgba(179, 50, 27, 0.12);
+  color: #b3321b;
 }
 
 .badge.info {
-  background: rgba(191, 219, 254, 0.7);
-  color: #1d4ed8;
+  background: rgba(192, 105, 77, 0.12);
+  color: var(--color-accent);
 }
 
 .badge.neutral {
-  background: rgba(226, 232, 240, 0.85);
-  color: #334155;
+  background: rgba(139, 57, 33, 0.08);
+  color: var(--color-ink);
 }
 
 .section-title {
@@ -164,10 +184,10 @@ main {
 .clients-toolbar-filters input,
 .clients-toolbar-filters select {
   border-radius: 999px;
-  border: 1px solid rgba(148, 163, 184, 0.4);
+  border: 1px solid rgba(139, 57, 33, 0.4);
   padding: 0.5rem 0.9rem;
   background: rgba(255, 255, 255, 0.85);
-  color: #1f2937;
+  color: #3f2216;
 }
 
 .clients-toolbar-filters button {
@@ -195,25 +215,25 @@ main {
 }
 
 .button.primary {
-  background: linear-gradient(135deg, #a5b4fc, #fbcfe8);
-  color: #312e81;
-  box-shadow: 0 12px 24px rgba(165, 180, 252, 0.35);
+  background: linear-gradient(135deg, #c0694d, #a54e34);
+  color: #fff5ef;
+  box-shadow: 0 12px 26px rgba(139, 57, 33, 0.25);
 }
 
 .button.primary:hover {
   transform: translateY(-1px);
-  box-shadow: 0 18px 36px rgba(165, 180, 252, 0.45);
+  box-shadow: 0 18px 38px rgba(139, 57, 33, 0.35);
 }
 
 .button.ghost {
-  background: transparent;
-  border-color: rgba(148, 163, 184, 0.45);
-  color: #475569;
+  background: rgba(139, 57, 33, 0.08);
+  border-color: rgba(139, 57, 33, 0.25);
+  color: var(--color-primary);
 }
 
 .button.ghost:hover {
-  border-color: rgba(79, 70, 229, 0.45);
-  color: #3730a3;
+  border-color: rgba(139, 57, 33, 0.45);
+  color: var(--color-primary-dark);
 }
 
 .form {
@@ -223,16 +243,16 @@ main {
 }
 
 .form-section {
-  border: 1px solid rgba(148, 163, 184, 0.25);
-  border-radius: 1rem;
-  padding: 1.25rem;
-  background: rgba(255, 255, 255, 0.85);
+  border: 1px solid rgba(139, 57, 33, 0.18);
+  border-radius: 1.1rem;
+  padding: 1.35rem;
+  background: rgba(255, 248, 241, 0.92);
 }
 
 .form-section legend {
   padding: 0 0.5rem;
   font-weight: 600;
-  color: #4338ca;
+  color: var(--color-primary);
 }
 
 .form-grid {
@@ -256,19 +276,19 @@ main {
 .form-grid input,
 .form-grid select,
 .form-grid textarea {
-  padding: 0.65rem 0.75rem;
+  padding: 0.7rem 0.85rem;
   border-radius: 0.75rem;
-  border: 1px solid rgba(148, 163, 184, 0.45);
+  border: 1px solid rgba(139, 57, 33, 0.2);
   background: rgba(255, 255, 255, 0.9);
-  color: #1f2937;
+  color: var(--color-ink);
 }
 
 .form-grid input:focus,
 .form-grid select:focus,
 .form-grid textarea:focus {
   outline: none;
-  border-color: rgba(129, 140, 248, 0.95);
-  box-shadow: 0 0 0 3px rgba(196, 181, 253, 0.4);
+  border-color: rgba(139, 57, 33, 0.55);
+  box-shadow: 0 0 0 3px rgba(192, 105, 77, 0.25);
 }
 
 .form-actions {
@@ -282,18 +302,18 @@ main {
 }
 
 .form-feedback.error {
-  color: #dc2626;
+  color: #b3321b;
 }
 
 .form-feedback.success {
-  color: #16a34a;
+  color: #2f7d4f;
 }
 
 .modal-backdrop {
   position: fixed;
   inset: 0;
-  background: rgba(148, 163, 184, 0.45);
-  backdrop-filter: blur(10px);
+  background: rgba(63, 34, 22, 0.25);
+  backdrop-filter: blur(12px);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -303,11 +323,11 @@ main {
 
 .modal {
   width: min(720px, 100%);
-  background: rgba(255, 255, 255, 0.95);
+  background: linear-gradient(180deg, rgba(255, 248, 241, 0.98), rgba(255, 255, 255, 0.94));
   border-radius: 1.5rem;
-  border: 1px solid rgba(148, 163, 184, 0.3);
-  box-shadow: 0 28px 60px rgba(148, 163, 184, 0.25);
-  padding: 1.75rem;
+  border: 1px solid rgba(139, 57, 33, 0.25);
+  box-shadow: var(--shadow-strong);
+  padding: 1.85rem;
   max-height: calc(100vh - 4rem);
   overflow-y: auto;
 }
@@ -325,15 +345,15 @@ main {
 }
 
 .clickable-row:hover {
-  background: rgba(196, 181, 253, 0.18);
+  background: rgba(192, 105, 77, 0.12);
 }
 
 .clickable-row.active {
-  background: rgba(196, 181, 253, 0.3);
+  background: rgba(139, 57, 33, 0.18);
 }
 
 .clickable-row.active:hover {
-  background: rgba(165, 180, 252, 0.35);
+  background: rgba(139, 57, 33, 0.24);
 }
 
 .back-link {
@@ -341,12 +361,12 @@ main {
   align-items: center;
   gap: 0.5rem;
   margin-bottom: 1rem;
-  color: #818cf8;
+  color: var(--color-primary);
   text-decoration: none;
 }
 
 .back-link:hover {
-  color: #6366f1;
+  color: var(--color-primary-dark);
 }
 
 .client-detail {
@@ -376,7 +396,7 @@ main {
   font-size: 0.85rem;
   text-transform: uppercase;
   letter-spacing: 0.08em;
-  color: #64748b;
+  color: var(--color-muted);
 }
 
 .definition-list dd {
@@ -408,9 +428,9 @@ main {
 }
 
 .button.ghost.active {
-  border-color: rgba(79, 70, 229, 0.6);
-  background: rgba(165, 180, 252, 0.22);
-  color: #3730a3;
+  border-color: rgba(139, 57, 33, 0.6);
+  background: rgba(139, 57, 33, 0.22);
+  color: #743621;
 }
 
 .timeline-visual {
@@ -424,7 +444,7 @@ main {
 
 .gantt-range {
   font-size: 0.85rem;
-  color: #64748b;
+  color: var(--color-muted);
 }
 
 .gantt-rows {
@@ -448,7 +468,7 @@ main {
   position: relative;
   height: 0.75rem;
   border-radius: 999px;
-  background: rgba(148, 163, 184, 0.25);
+  background: rgba(139, 57, 33, 0.25);
   overflow: hidden;
 }
 
@@ -457,8 +477,8 @@ main {
   top: 0;
   bottom: 0;
   border-radius: 999px;
-  background: linear-gradient(135deg, #a5b4fc, #fbcfe8);
-  box-shadow: 0 8px 16px rgba(165, 180, 252, 0.35);
+  background: linear-gradient(135deg, #8b3921, #c0694d);
+  box-shadow: 0 8px 16px rgba(139, 57, 33, 0.35);
 }
 
 .calendar-wrapper {
@@ -477,7 +497,7 @@ main {
 .calendar-header-title {
   font-weight: 600;
   font-size: 1rem;
-  color: #4338ca;
+  color: #8b3921;
 }
 
 .calendar-grid {
@@ -492,19 +512,19 @@ main {
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.08em;
-  color: #94a3b8;
+  color: #c4a799;
 }
 
 .calendar-day {
   background: rgba(255, 255, 255, 0.9);
-  border: 1px solid rgba(148, 163, 184, 0.2);
+  border: 1px solid rgba(139, 57, 33, 0.2);
   border-radius: 0.75rem;
   padding: 0.5rem;
   min-height: 110px;
   display: flex;
   flex-direction: column;
   gap: 0.35rem;
-  box-shadow: 0 8px 18px rgba(148, 163, 184, 0.12);
+  box-shadow: 0 8px 18px rgba(139, 57, 33, 0.12);
 }
 
 .calendar-day.muted {
@@ -513,7 +533,7 @@ main {
 
 .calendar-date {
   font-weight: 600;
-  color: #475569;
+  color: #6f4d3d;
 }
 
 .calendar-task {
@@ -521,8 +541,8 @@ main {
   padding: 0.25rem 0.5rem;
   border-radius: 999px;
   font-weight: 600;
-  background: rgba(148, 163, 184, 0.3);
-  color: #475569;
+  background: rgba(139, 57, 33, 0.3);
+  color: #6f4d3d;
 }
 
 .sr-only {
@@ -563,10 +583,10 @@ main {
 
 .crm-metric-card {
   background: rgba(255, 255, 255, 0.92);
-  border: 1px solid rgba(148, 163, 184, 0.25);
+  border: 1px solid rgba(139, 57, 33, 0.25);
   border-radius: 1rem;
   padding: 1.25rem;
-  box-shadow: 0 20px 40px rgba(148, 163, 184, 0.15);
+  box-shadow: 0 20px 40px rgba(139, 57, 33, 0.15);
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
@@ -576,19 +596,19 @@ main {
   margin: 0;
   font-size: 0.95rem;
   font-weight: 600;
-  color: #1f2937;
+  color: #3f2216;
 }
 
 .crm-metric-description {
   margin: 0;
   font-size: 0.85rem;
-  color: #64748b;
+  color: var(--color-muted);
 }
 
 .crm-metric-value {
   font-size: 1.65rem;
   font-weight: 700;
-  color: #4338ca;
+  color: #8b3921;
 }
 
 .crm-overview-grid {
@@ -608,10 +628,10 @@ main {
 
 .crm-section {
   background: rgba(255, 255, 255, 0.92);
-  border: 1px solid rgba(148, 163, 184, 0.25);
+  border: 1px solid rgba(139, 57, 33, 0.25);
   border-radius: 1rem;
   padding: 1.25rem;
-  box-shadow: 0 18px 32px rgba(148, 163, 184, 0.14);
+  box-shadow: 0 18px 32px rgba(139, 57, 33, 0.14);
   display: flex;
   flex-direction: column;
   gap: 1.25rem;
@@ -625,7 +645,7 @@ main {
 .crm-section-subtitle {
   margin: 0;
   font-size: 0.85rem;
-  color: #64748b;
+  color: var(--color-muted);
 }
 
 .crm-pipeline-table td,
@@ -643,8 +663,8 @@ main {
   display: inline-flex;
   padding: 0.25rem 0.5rem;
   border-radius: 0.75rem;
-  background: rgba(250, 204, 21, 0.15);
-  color: #92400e;
+  background: rgba(212, 160, 23, 0.18);
+  color: #c1611a;
   font-weight: 600;
 }
 
@@ -657,9 +677,9 @@ main {
 }
 
 .crm-gap-item {
-  background: rgba(248, 250, 252, 0.9);
+  background: rgba(255, 244, 236, 0.9);
   border-radius: 0.85rem;
-  border: 1px solid rgba(203, 213, 225, 0.6);
+  border: 1px solid rgba(226, 191, 166, 0.6);
   padding: 0.9rem 1rem;
   display: grid;
   gap: 0.5rem;
@@ -667,7 +687,7 @@ main {
 
 .crm-gap-item.empty {
   text-align: center;
-  color: #64748b;
+  color: var(--color-muted);
   font-size: 0.9rem;
   border-style: dashed;
 }
@@ -680,7 +700,7 @@ main {
 
 .crm-gap-name {
   font-weight: 600;
-  color: #1f2937;
+  color: #3f2216;
 }
 
 .crm-gap-meta {
@@ -688,19 +708,19 @@ main {
   flex-wrap: wrap;
   gap: 0.75rem;
   font-size: 0.85rem;
-  color: #475569;
+  color: #6f4d3d;
 }
 
 .crm-gap-action {
   margin: 0;
   font-size: 0.9rem;
-  color: #4338ca;
+  color: #8b3921;
   font-weight: 500;
 }
 
 .crm-org-meta {
   font-size: 0.8rem;
-  color: #64748b;
+  color: var(--color-muted);
   margin-top: 0.35rem;
 }
 
@@ -710,64 +730,64 @@ main {
 }
 
 .crm-contact-cell.empty {
-  color: #b91c1c;
+  color: #b3321b;
   font-weight: 500;
 }
 
 .crm-contact-count {
   font-weight: 600;
-  color: #1f2937;
+  color: #3f2216;
 }
 
 .crm-contact-primary {
   font-size: 0.85rem;
-  color: #475569;
+  color: #6f4d3d;
 }
 
 .crm-last-touch {
   font-weight: 600;
-  color: #475569;
+  color: #6f4d3d;
 }
 
 .crm-last-touch.fresh {
-  color: #047857;
+  color: #2f7d4f;
 }
 
 .crm-last-touch.stale {
-  color: #b91c1c;
+  color: #b3321b;
 }
 
 .crm-result-count {
   font-size: 0.85rem;
-  color: #475569;
+  color: #6f4d3d;
   font-weight: 500;
 }
 
 .table-empty {
   text-align: center;
   padding: 2rem 1rem;
-  color: #64748b;
+  color: var(--color-muted);
   font-size: 0.95rem;
 }
 
 .calendar-task.status-in_progress {
   background: rgba(253, 230, 138, 0.4);
-  color: #92400e;
+  color: #c1611a;
 }
 
 .calendar-task.status-review {
-  background: rgba(196, 181, 253, 0.4);
-  color: #6d28d9;
+  background: rgba(192, 105, 77, 0.4);
+  color: #8b3921;
 }
 
 .calendar-task.status-done {
   background: rgba(187, 247, 208, 0.55);
-  color: #15803d;
+  color: #2f7d4f;
 }
 
 .calendar-task.status-todo {
-  background: rgba(148, 163, 184, 0.3);
-  color: #475569;
+  background: rgba(139, 57, 33, 0.3);
+  color: #6f4d3d;
 }
 
 .metric {
@@ -775,11 +795,11 @@ main {
   justify-content: space-between;
   align-items: baseline;
   padding: 0.75rem 0;
-  border-bottom: 1px solid rgba(148, 163, 184, 0.18);
+  border-bottom: 1px solid rgba(139, 57, 33, 0.18);
 }
 
 .metric span {
-  color: #64748b;
+  color: var(--color-muted);
   text-transform: uppercase;
   font-size: 0.75rem;
   letter-spacing: 0.08em;

--- a/frontend/app/hr/page.tsx
+++ b/frontend/app/hr/page.tsx
@@ -85,7 +85,7 @@ export default async function PeoplePage(): Promise<JSX.Element> {
           <tbody>
             {timeOff.length === 0 ? (
               <tr>
-                <td colSpan={4} style={{ textAlign: "center", color: "#64748b" }}>
+                <td colSpan={4} style={{ textAlign: "center", color: "#8c6f63" }}>
                   No upcoming leave requests.
                 </td>
               </tr>
@@ -99,15 +99,15 @@ export default async function PeoplePage(): Promise<JSX.Element> {
                   <td style={{ textTransform: "capitalize" }}>{request.status}</td>
                   <td>
                     {timeOffActions.has(request.id) ? (
-                      <Link
-                        href={timeOffActions.get(request.id)!.url}
-                        style={{ color: "#6366f1", textDecoration: "none", fontWeight: 600 }}
-                      >
-                        {timeOffActions.get(request.id)!.label}
-                      </Link>
-                    ) : (
-                      <span style={{ color: "#64748b" }}>—</span>
-                    )}
+                    <Link
+                      href={timeOffActions.get(request.id)!.url}
+                      style={{ color: "#8b3921", textDecoration: "none", fontWeight: 600 }}
+                    >
+                      {timeOffActions.get(request.id)!.label}
+                    </Link>
+                  ) : (
+                    <span style={{ color: "#8c6f63" }}>—</span>
+                  )}
                   </td>
                 </tr>
               ))

--- a/frontend/app/marketing/page.tsx
+++ b/frontend/app/marketing/page.tsx
@@ -60,16 +60,16 @@ export default async function MarketingPage(): Promise<JSX.Element> {
               <li key={task.id} style={{ display: "flex", justifyContent: "space-between", gap: "1rem" }}>
                 <div>
                   <p style={{ margin: 0, fontWeight: 600 }}>{task.summary}</p>
-                  {task.details && <p style={{ margin: "0.25rem 0", color: "#64748b" }}>{task.details}</p>}
+                  {task.details && <p style={{ margin: "0.25rem 0", color: "#8c6f63" }}>{task.details}</p>}
                   {task.due_at && (
-                    <p style={{ margin: 0, fontSize: "0.85rem", color: "#64748b" }}>
+                    <p style={{ margin: 0, fontSize: "0.85rem", color: "#8c6f63" }}>
                       Due {new Date(task.due_at).toLocaleString()}
                     </p>
                   )}
                 </div>
                 <Link
                   href={task.action_url ?? "/marketing"}
-                  style={{ color: "#6366f1", fontWeight: 600, textDecoration: "none", alignSelf: "center" }}
+                  style={{ color: "#8b3921", fontWeight: 600, textDecoration: "none", alignSelf: "center" }}
                 >
                   {task.action_label ?? "Open"}
                 </Link>

--- a/frontend/app/projects/ProjectsDashboard.tsx
+++ b/frontend/app/projects/ProjectsDashboard.tsx
@@ -988,10 +988,10 @@ export default function ProjectsDashboard({ initialProjects }: ProjectsDashboard
               >
                 <div
                   style={{
-                    border: "1px solid #e2e8f0",
+                    border: "1px solid #f1d9cc",
                     borderRadius: "0.75rem",
                     padding: "1rem",
-                    background: "#f8fafc"
+                    background: "#fdf4ec"
                   }}
                 >
                   <h4 style={{ margin: "0 0 0.5rem 0" }}>Active sprint</h4>
@@ -1006,7 +1006,7 @@ export default function ProjectsDashboard({ initialProjects }: ProjectsDashboard
                         <div
                           style={{
                             height: "8px",
-                            background: "#e2e8f0",
+                            background: "#f1d9cc",
                             borderRadius: "999px",
                             overflow: "hidden",
                             marginTop: "0.35rem"
@@ -1015,7 +1015,7 @@ export default function ProjectsDashboard({ initialProjects }: ProjectsDashboard
                           <div
                             style={{
                               width: `${sprintProgress}%`,
-                              background: "#6366f1",
+                              background: "#8b3921",
                               height: "100%"
                             }}
                           />
@@ -1053,10 +1053,10 @@ export default function ProjectsDashboard({ initialProjects }: ProjectsDashboard
                 </div>
                 <div
                   style={{
-                    border: "1px solid #e2e8f0",
+                    border: "1px solid #f1d9cc",
                     borderRadius: "0.75rem",
                     padding: "1rem",
-                    background: "#f8fafc"
+                    background: "#fdf4ec"
                   }}
                 >
                   <h4 style={{ margin: "0 0 0.5rem 0" }}>Agile delivery metrics</h4>

--- a/frontend/app/support/page.tsx
+++ b/frontend/app/support/page.tsx
@@ -69,12 +69,12 @@ export default async function SupportPage(): Promise<JSX.Element> {
                 {ticketActions.has(ticket.id) ? (
                   <Link
                     href={ticketActions.get(ticket.id)!.url}
-                    style={{ color: "#6366f1", textDecoration: "none", fontWeight: 600 }}
+                    style={{ color: "#8b3921", textDecoration: "none", fontWeight: 600 }}
                   >
                     {ticketActions.get(ticket.id)!.label}
                   </Link>
                 ) : (
-                  <span style={{ color: "#64748b" }}>—</span>
+                  <span style={{ color: "#8c6f63" }}>—</span>
                 )}
               </td>
             </tr>


### PR DESCRIPTION
## Summary
- adopt a warm earth-tone palette in global styles, cards, badges, and controls
- refresh the sidebar, top bar, and metric cards to match the updated brand accents
- retheme automation, financial, and support workflows so links, tables, and actions use the new colors

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dc8b79ca548333aa7760576c2e7a2e