### PR TITLE
Add background launch controls for dev servers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ __pycache__/
 .DS_Store
 .idea/
 .vscode/
+.devserver/

--- a/README.md
+++ b/README.md
@@ -230,13 +230,17 @@ For convenience the repository provides wrapper scripts that set up dependencies
 
 ```bash
 # macOS/Linux
-./launch.sh
+./launch.sh up          # start in the background
+./launch.sh logs        # stream combined logs
+./launch.sh down        # stop background services
 
 # Windows (PowerShell)
-pwsh -File launch.ps1
+pwsh -File launch.ps1 up
+pwsh -File launch.ps1 logs
+pwsh -File launch.ps1 down
 ```
 
-Both scripts automatically create the backend virtual environment, install/update dependencies, load environment variables from any available `.env` files, and then run the FastAPI and Next.js development servers. When you are finished, press <kbd>Ctrl</kbd>+<kbd>C</kbd> in the same terminal and the scripts will shut down both processes cleanly.
+Both scripts automatically create the backend virtual environment, install/update dependencies, and load environment variables from any available `.env` files. By default they keep the FastAPI and Next.js development servers running in the background so you can continue working (and commit code) from the same terminal. Pass `foreground` instead of `up` if you prefer the original blocking behaviour.
 
 ## Testing
 ⚠️ Tests not run (planning document only).

--- a/launch.ps1
+++ b/launch.ps1
@@ -1,15 +1,56 @@
 #requires -version 5.1
 [CmdletBinding()]
-param()
+param(
+    [Parameter(Position = 0)]
+    [string]$Command = 'dev',
+    [Parameter(Position = 1)]
+    [string]$Target = 'all'
+)
+
+function Show-Usage {
+    @'
+Usage: .\launch.ps1 [command] [logsTarget]
+
+Commands:
+  dev|run|foreground    Start backend and frontend in the foreground (default)
+  up|start|background   Start backend and frontend in the background and return to the shell
+  down|stop             Stop background services
+  restart               Restart background services
+  status                Show background service status
+  logs [service]        Tail logs for backend, frontend, or both (default)
+
+Examples:
+  .\launch.ps1 up             # start both services in the background
+  .\launch.ps1 logs backend   # follow backend logs
+  .\launch.ps1 down           # stop background services
+  .\launch.ps1                # run both services in the foreground (original behaviour)
+'@
+}
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
+
+$validCommands = @('dev', 'run', 'foreground', 'up', 'start', 'background', 'down', 'stop', 'restart', 'status', 'logs', 'help', '--help', '-h')
+$normalizedCommand = $Command.ToLowerInvariant()
+if (-not $validCommands.Contains($normalizedCommand)) {
+    Write-Error "Unknown command '$Command'."
+    Show-Usage
+    exit 1
+}
+
+if ($normalizedCommand -in @('help', '--help', '-h')) {
+    Show-Usage
+    exit 0
+}
 
 $RootDir = Split-Path -Parent $PSCommandPath
 Set-Location $RootDir
 $BackendDir = Join-Path $RootDir 'backend'
 $FrontendDir = Join-Path $RootDir 'frontend'
 $BackendVenv = Join-Path $BackendDir '.venv'
+$DevStateDir = Join-Path $RootDir '.devserver'
+$PidDir = Join-Path $DevStateDir 'pids'
+$LogDir = Join-Path $DevStateDir 'logs'
 
 function Write-Info {
     param([string]$Message)
@@ -19,6 +60,14 @@ function Write-Info {
 function Write-ErrorMessage {
     param([string]$Message)
     Write-Host "[ERROR] $Message" -ForegroundColor Red
+}
+
+function Ensure-StateDirectories {
+    foreach ($dir in @($DevStateDir, $PidDir, $LogDir)) {
+        if (-not (Test-Path $dir -PathType Container)) {
+            New-Item -ItemType Directory -Path $dir | Out-Null
+        }
+    }
 }
 
 function Check-Command {
@@ -97,6 +146,236 @@ function Load-DotEnv {
     }
 }
 
+$script:PythonCommandParts = @()
+$script:VenvPython = $null
+
+function Ensure-Prerequisites {
+    if ($script:PythonCommandParts.Count -eq 0) {
+        $script:PythonCommandParts = Detect-Python
+    }
+
+    $pythonExe = $script:PythonCommandParts[0]
+    $pythonArgs = if ($script:PythonCommandParts.Count -gt 1) { $script:PythonCommandParts[1..($script:PythonCommandParts.Count - 1)] } else { @() }
+    $pythonDisplay = ($script:PythonCommandParts -join ' ')
+
+    try {
+        & $pythonExe @pythonArgs '-m' 'pip' '--version' *> $null
+    }
+    catch {
+        throw "pip for Python 3 is not available. Install pip (usually via '$pythonDisplay -m ensurepip --upgrade' or the Microsoft Store installer)."
+    }
+
+    Check-Command -Command 'node' -FriendlyName 'Node.js'
+    Check-Command -Command 'npm' -FriendlyName 'npm (Node Package Manager)'
+
+    Load-DotEnv (Join-Path $RootDir '.env')
+
+    $venvPythonWin = Join-Path $BackendVenv 'Scripts/python.exe'
+    $venvPythonUnix = Join-Path $BackendVenv 'bin/python'
+
+    if (-not (Test-Path $venvPythonWin) -and -not (Test-Path $venvPythonUnix)) {
+        Write-Info "Creating Python virtual environment for backend at $BackendVenv"
+        & $pythonExe @pythonArgs '-m' 'venv' $BackendVenv
+    }
+
+    if (Test-Path $venvPythonWin) {
+        $script:VenvPython = $venvPythonWin
+    }
+    elseif (Test-Path $venvPythonUnix) {
+        $script:VenvPython = $venvPythonUnix
+    }
+    else {
+        throw "Unable to locate the Python interpreter inside the virtual environment at $BackendVenv."
+    }
+
+    Write-Info 'Installing backend dependencies...'
+    & $script:VenvPython '-m' 'pip' 'install' '-r' (Join-Path $BackendDir 'requirements.txt')
+
+    $frontendNodeModules = Join-Path $FrontendDir 'node_modules'
+    if (-not (Test-Path $frontendNodeModules)) {
+        Write-Info 'Installing frontend dependencies (this may take a moment)...'
+        Push-Location $FrontendDir
+        try {
+            npm install | Out-Null
+        }
+        finally {
+            Pop-Location
+        }
+    }
+    else {
+        Write-Info 'Frontend dependencies already installed.'
+    }
+}
+
+function Get-PidPath {
+    param([string]$Name)
+    return (Join-Path $PidDir "$Name.pid")
+}
+
+function Get-LogPath {
+    param([string]$Name)
+    return (Join-Path $LogDir "$Name.log")
+}
+
+function Get-ProcessFromPidFile {
+    param([string]$PidPath)
+
+    if (-not (Test-Path $PidPath -PathType Leaf)) {
+        return $null
+    }
+
+    $pidText = Get-Content $PidPath | Select-Object -First 1
+    if ([string]::IsNullOrWhiteSpace($pidText)) {
+        return $null
+    }
+
+    $pidValue = 0
+    if (-not [int]::TryParse($pidText, [ref]$pidValue)) {
+        return $null
+    }
+
+    try {
+        return Get-Process -Id $pidValue -ErrorAction Stop
+    }
+    catch {
+        return $null
+    }
+}
+
+function Start-BackgroundService {
+    param(
+        [string]$Name,
+        [string]$FilePath,
+        [string[]]$Arguments,
+        [string]$WorkingDirectory
+    )
+
+    $pidPath = Get-PidPath $Name
+    $existing = Get-ProcessFromPidFile $pidPath
+    if ($null -ne $existing) {
+        Write-Info "$Name is already running (PID $($existing.Id))."
+        return
+    }
+
+    if (Test-Path $pidPath -PathType Leaf) {
+        Remove-Item $pidPath -Force
+    }
+
+    $logPath = Get-LogPath $Name
+    if (Test-Path $logPath -PathType Leaf) {
+        Clear-Content $logPath
+    }
+    else {
+        New-Item -ItemType File -Path $logPath | Out-Null
+    }
+
+    Write-Info "Starting $Name in background (logs: $logPath)..."
+    $process = Start-Process -FilePath $FilePath -ArgumentList $Arguments -WorkingDirectory $WorkingDirectory -RedirectStandardOutput $logPath -RedirectStandardError $logPath -WindowStyle Hidden -PassThru
+    Set-Content -Path $pidPath -Value $process.Id
+    Write-Info "$Name started with PID $($process.Id)."
+}
+
+function Stop-BackgroundService {
+    param([string]$Name)
+
+    $pidPath = Get-PidPath $Name
+    if (-not (Test-Path $pidPath -PathType Leaf)) {
+        Write-Info "$Name is not running."
+        return
+    }
+
+    $process = Get-ProcessFromPidFile $pidPath
+    if ($null -eq $process) {
+        Write-Info "$Name was not running but a PID file was present."
+        Remove-Item $pidPath -Force
+        return
+    }
+
+    Write-Info "Stopping $Name (PID $($process.Id))..."
+    try {
+        Stop-Process -Id $process.Id -ErrorAction Stop
+    }
+    catch {
+        Write-ErrorMessage "Failed to send stop signal to $Name (PID $($process.Id))."
+    }
+
+    try {
+        $process.WaitForExit(5000) | Out-Null
+    }
+    catch {
+    }
+
+    if (-not $process.HasExited) {
+        Write-Info "$Name did not terminate gracefully; forcing stop."
+        try {
+            Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue
+        }
+        catch {
+        }
+    }
+
+    Remove-Item $pidPath -Force
+}
+
+function Start-BackgroundServices {
+    Ensure-StateDirectories
+
+    Load-DotEnv (Join-Path $BackendDir '.env')
+    Start-BackgroundService -Name 'backend' -FilePath $script:VenvPython -Arguments @('-m', 'uvicorn', 'app.main:app', '--reload') -WorkingDirectory $BackendDir
+
+    Load-DotEnv (Join-Path $FrontendDir '.env')
+    Start-BackgroundService -Name 'frontend' -FilePath 'npm' -Arguments @('run', 'dev') -WorkingDirectory $FrontendDir
+
+    Write-Info "Background services running. Use '.\launch.ps1 logs' to follow output or '.\launch.ps1 down' to stop."
+}
+
+function Stop-BackgroundServices {
+    Stop-BackgroundService -Name 'frontend'
+    Stop-BackgroundService -Name 'backend'
+    Write-Info 'Background services stopped.'
+}
+
+function Show-Status {
+    Ensure-StateDirectories
+
+    foreach ($name in 'backend', 'frontend') {
+        $pidPath = Get-PidPath $name
+        $process = Get-ProcessFromPidFile $pidPath
+        if ($null -ne $process) {
+            Write-Host "$name: running (PID $($process.Id))"
+        }
+        else {
+            Write-Host "$name: stopped"
+        }
+    }
+
+    Write-Host 'Log files:'
+    Write-Host "  Backend : $(Get-LogPath 'backend')"
+    Write-Host "  Frontend: $(Get-LogPath 'frontend')"
+}
+
+function Tail-Logs {
+    param([string]$Target)
+
+    Ensure-StateDirectories
+    $targetNormalized = $Target.ToLowerInvariant()
+
+    switch ($targetNormalized) {
+        'backend' {
+            Write-Info 'Streaming backend logs...'
+            Get-Content -Path (Get-LogPath 'backend') -Tail 20 -Wait
+        }
+        'frontend' {
+            Write-Info 'Streaming frontend logs...'
+            Get-Content -Path (Get-LogPath 'frontend') -Tail 20 -Wait
+        }
+        default {
+            Write-Info 'Streaming backend and frontend logs...'
+            Get-Content -Path (Get-LogPath 'backend'), (Get-LogPath 'frontend') -Tail 20 -Wait
+        }
+    }
+}
+
 function Stop-Processes {
     param([System.Diagnostics.Process[]]$Processes)
 
@@ -121,116 +400,92 @@ function Stop-Processes {
     }
 }
 
-$pythonCommandParts = Detect-Python
-$pythonExe = $pythonCommandParts[0]
-$pythonArgs = if ($pythonCommandParts.Count -gt 1) { $pythonCommandParts[1..($pythonCommandParts.Count - 1)] } else { @() }
-$pythonDisplay = ($pythonCommandParts -join ' ')
+function Start-ForegroundServices {
+    Load-DotEnv (Join-Path $BackendDir '.env')
+    Write-Info 'Starting backend server...'
+    $backendProcess = Start-Process -FilePath $script:VenvPython -ArgumentList @('-m', 'uvicorn', 'app.main:app', '--reload') -WorkingDirectory $BackendDir -PassThru -NoNewWindow
+    Write-Info "Backend server started (PID $($backendProcess.Id))."
 
-try {
-    & $pythonExe @pythonArgs '-m' 'pip' '--version' *> $null
-}
-catch {
-    throw "pip for Python 3 is not available. Install pip (usually via '$pythonDisplay -m ensurepip --upgrade' or the Microsoft Store installer)."
-}
+    Load-DotEnv (Join-Path $FrontendDir '.env')
+    Write-Info 'Starting frontend server...'
+    $frontendProcess = Start-Process -FilePath 'npm' -ArgumentList @('run', 'dev') -WorkingDirectory $FrontendDir -PassThru -NoNewWindow
+    Write-Info "Frontend server started (PID $($frontendProcess.Id))."
 
-Check-Command -Command 'node' -FriendlyName 'Node.js'
-Check-Command -Command 'npm' -FriendlyName 'npm (Node Package Manager)'
+    $script:LaunchProcesses = @($backendProcess, $frontendProcess)
+    $script:StopRequested = $false
+    $script:ExitCode = 0
 
-Load-DotEnv (Join-Path $RootDir '.env')
+    $cancelRegistration = Register-EngineEvent -SourceIdentifier ConsoleCancelEvent -SupportEvent -Action {
+        param($sender, $eventArgs)
+        $eventArgs.Cancel = $true
+        Write-Host ''
+        Write-Host '[INFO] Ctrl+C detected. Stopping services...' -ForegroundColor Cyan
+        Set-Variable -Name StopRequested -Scope Script -Value $true
+    }
 
-$venvPython = $null
-$venvPythonWin = Join-Path $BackendVenv 'Scripts/python.exe'
-$venvPythonUnix = Join-Path $BackendVenv 'bin/python'
+    Write-Info 'Both services are running. Press Ctrl+C to stop.'
 
-if (-not (Test-Path $venvPythonWin) -and -not (Test-Path $venvPythonUnix)) {
-    Write-Info "Creating Python virtual environment for backend at $BackendVenv"
-    & $pythonExe @pythonArgs '-m' 'venv' $BackendVenv
-}
-
-if (Test-Path $venvPythonWin) {
-    $venvPython = $venvPythonWin
-}
-elseif (Test-Path $venvPythonUnix) {
-    $venvPython = $venvPythonUnix
-}
-else {
-    throw "Unable to locate the Python interpreter inside the virtual environment at $BackendVenv."
-}
-
-Write-Info 'Installing backend dependencies...'
-& $venvPython '-m' 'pip' 'install' '-r' (Join-Path $BackendDir 'requirements.txt')
-
-$frontendNodeModules = Join-Path $FrontendDir 'node_modules'
-if (-not (Test-Path $frontendNodeModules)) {
-    Write-Info 'Installing frontend dependencies (this may take a moment)...'
-    Push-Location $FrontendDir
     try {
-        npm install
+        while (-not $script:StopRequested) {
+            foreach ($proc in $script:LaunchProcesses) {
+                if ($null -eq $proc) {
+                    continue
+                }
+                if ($proc.HasExited) {
+                    if ($proc.ExitCode -ne 0 -and $script:ExitCode -eq 0) {
+                        Set-Variable -Name ExitCode -Scope Script -Value $proc.ExitCode
+                        Write-ErrorMessage "Process PID $($proc.Id) exited unexpectedly with status $($proc.ExitCode)."
+                    }
+                    else {
+                        Write-Info "Process PID $($proc.Id) exited."
+                    }
+                    Set-Variable -Name StopRequested -Scope Script -Value $true
+                    break
+                }
+            }
+
+            if (-not $script:StopRequested) {
+                Start-Sleep -Milliseconds 500
+            }
+        }
     }
     finally {
-        Pop-Location
-    }
-}
-else {
-    Write-Info 'Frontend dependencies already installed.'
-}
-
-Load-DotEnv (Join-Path $BackendDir '.env')
-Write-Info 'Starting backend server...'
-$backendProcess = Start-Process -FilePath $venvPython -ArgumentList @('-m', 'uvicorn', 'app.main:app', '--reload') -WorkingDirectory $BackendDir -PassThru -NoNewWindow
-Write-Info "Backend server started (PID $($backendProcess.Id))."
-
-Load-DotEnv (Join-Path $FrontendDir '.env')
-Write-Info 'Starting frontend server...'
-$frontendProcess = Start-Process -FilePath 'npm' -ArgumentList @('run', 'dev') -WorkingDirectory $FrontendDir -PassThru -NoNewWindow
-Write-Info "Frontend server started (PID $($frontendProcess.Id))."
-
-$script:LaunchProcesses = @($backendProcess, $frontendProcess)
-$script:StopRequested = $false
-$script:ExitCode = 0
-
-$cancelRegistration = Register-EngineEvent -SourceIdentifier ConsoleCancelEvent -SupportEvent -Action {
-    param($sender, $eventArgs)
-    $eventArgs.Cancel = $true
-    Write-Host ''
-    Write-Host '[INFO] Ctrl+C detected. Stopping services...' -ForegroundColor Cyan
-    Set-Variable -Name StopRequested -Scope Script -Value $true
-}
-
-Write-Info 'Both services are running. Press Ctrl+C to stop.'
-
-try {
-    while (-not $script:StopRequested) {
-        foreach ($proc in $script:LaunchProcesses) {
-            if ($null -eq $proc) {
-                continue
-            }
-            if ($proc.HasExited) {
-                if ($proc.ExitCode -ne 0 -and $script:ExitCode -eq 0) {
-                    Set-Variable -Name ExitCode -Scope Script -Value $proc.ExitCode
-                    Write-ErrorMessage "Process PID $($proc.Id) exited unexpectedly with status $($proc.ExitCode)."
-                }
-                else {
-                    Write-Info "Process PID $($proc.Id) exited."
-                }
-                Set-Variable -Name StopRequested -Scope Script -Value $true
-                break
-            }
+        Write-Host ''
+        Write-Info 'Shutting down services...'
+        Stop-Processes -Processes $script:LaunchProcesses
+        if ($null -ne $cancelRegistration) {
+            Unregister-Event -SourceIdentifier ConsoleCancelEvent -ErrorAction SilentlyContinue
         }
+        Write-Info 'All services stopped.'
+    }
 
-        if (-not $script:StopRequested) {
-            Start-Sleep -Milliseconds 500
-        }
-    }
-}
-finally {
-    Write-Host ''
-    Write-Info 'Shutting down services...'
-    Stop-Processes -Processes $script:LaunchProcesses
-    if ($null -ne $cancelRegistration) {
-        Unregister-Event -SourceIdentifier ConsoleCancelEvent -ErrorAction SilentlyContinue
-    }
-    Write-Info 'All services stopped.'
+    exit $script:ExitCode
 }
 
-exit $script:ExitCode
+switch ($normalizedCommand) {
+    {$_ -in 'dev', 'run', 'foreground'} {
+        Ensure-Prerequisites
+        Start-ForegroundServices
+    }
+    {$_ -in 'up', 'start', 'background'} {
+        Ensure-Prerequisites
+        Start-BackgroundServices
+    }
+    {$_ -in 'down', 'stop'} {
+        Stop-BackgroundServices
+    }
+    'restart' {
+        Stop-BackgroundServices
+        Ensure-Prerequisites
+        Start-BackgroundServices
+    }
+    'status' {
+        Show-Status
+    }
+    'logs' {
+        Tail-Logs -Target $Target
+    }
+    default {
+        Show-Usage
+    }
+}

--- a/launch.sh
+++ b/launch.sh
@@ -1,14 +1,18 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+COMMAND="${1:-dev}"
+
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 BACKEND_DIR="$ROOT_DIR/backend"
 FRONTEND_DIR="$ROOT_DIR/frontend"
 BACKEND_VENV="$BACKEND_DIR/.venv"
-BACKEND_PYTHON=""
+DEV_STATE_DIR="$ROOT_DIR/.devserver"
+PID_DIR="$DEV_STATE_DIR/pids"
+LOG_DIR="$DEV_STATE_DIR/logs"
 
-PIDS=()
-CLEANED_UP=0
+PYTHON_CMD=()
+BACKEND_PYTHON=""
 
 error() {
   echo "[ERROR] $1" >&2
@@ -16,6 +20,26 @@ error() {
 
 info() {
   echo "[INFO] $1"
+}
+
+usage() {
+  cat <<'USAGE'
+Usage: ./launch.sh [command]
+
+Commands:
+  dev|run|foreground   Start backend and frontend in the foreground (default)
+  up|start|background  Start backend and frontend in the background and return the shell
+  down|stop            Stop background services
+  restart              Restart background services
+  status               Show background service status
+  logs [service]       Tail logs for backend, frontend, or both (default)
+
+Examples:
+  ./launch.sh up          # start both services in the background
+  ./launch.sh logs        # follow combined logs from background services
+  ./launch.sh down        # stop background services
+  ./launch.sh             # run both services in the foreground (original behaviour)
+USAGE
 }
 
 check_command() {
@@ -27,46 +51,6 @@ check_command() {
   fi
 }
 
-load_env_if_present() {
-  local env_file="$1"
-  if [ -f "$env_file" ]; then
-    info "Loading environment variables from $env_file"
-    # shellcheck disable=SC1090
-    set -a
-    source "$env_file"
-    set +a
-  else
-    info "No environment file found at $env_file (skipping)."
-    if [ -f "$env_file.example" ]; then
-      info "Consider copying $env_file.example to $env_file and updating the values."
-    fi
-  fi
-}
-
-cleanup() {
-  if [ "$CLEANED_UP" -eq 1 ]; then
-    return
-  fi
-  CLEANED_UP=1
-  echo
-  info "Shutting down services..."
-  for pid in "${PIDS[@]}"; do
-    if [ -n "${pid:-}" ] && kill -0 "$pid" >/dev/null 2>&1; then
-      kill "$pid" >/dev/null 2>&1 || true
-    fi
-  done
-  for pid in "${PIDS[@]}"; do
-    if [ -n "${pid:-}" ]; then
-      wait "$pid" >/dev/null 2>&1 || true
-    fi
-  done
-  info "All services stopped."
-}
-
-trap 'cleanup; exit 0' INT TERM
-trap cleanup EXIT
-
-# 1. Verify prerequisites
 detect_python() {
   local candidate
   for candidate in "python3" "python" "py -3" "py"; do
@@ -95,66 +79,123 @@ detect_python() {
   return 1
 }
 
-read -r -a PYTHON_CMD <<<"$(detect_python || true)"
-if [ "${#PYTHON_CMD[@]}" -eq 0 ]; then
-  error "Python 3 executable not found. Install Python 3 and ensure it is on your PATH."
-  exit 1
-fi
+load_env_if_present() {
+  local env_file="$1"
+  if [ -f "$env_file" ]; then
+    info "Loading environment variables from $env_file"
+    # shellcheck disable=SC1090
+    set -a
+    source "$env_file"
+    set +a
+  else
+    info "No environment file found at $env_file (skipping)."
+    if [ -f "$env_file.example" ]; then
+      info "Consider copying $env_file.example to $env_file and updating the values."
+    fi
+  fi
+}
 
-python_display="${PYTHON_CMD[*]}"
+ensure_prerequisites() {
+  if [ "${#PYTHON_CMD[@]}" -eq 0 ]; then
+    read -r -a PYTHON_CMD <<<"$(detect_python || true)"
+  fi
 
-if ! "${PYTHON_CMD[@]}" -m pip --version >/dev/null 2>&1; then
-  error "pip for Python 3 is not available. Install pip (usually via '$python_display -m ensurepip --upgrade' or your package manager)."
-  exit 1
-fi
-check_command node "Node.js"
-check_command npm "npm (Node Package Manager)"
+  if [ "${#PYTHON_CMD[@]}" -eq 0 ]; then
+    error "Python 3 executable not found. Install Python 3 and ensure it is on your PATH."
+    exit 1
+  fi
 
-# 2. Load root environment file if present
-load_env_if_present "$ROOT_DIR/.env"
+  local python_display="${PYTHON_CMD[*]}"
 
-# 3. Prepare backend virtual environment
-if [ ! -x "$BACKEND_VENV/bin/python" ] && [ ! -x "$BACKEND_VENV/Scripts/python.exe" ]; then
-  info "Creating Python virtual environment for backend at $BACKEND_VENV"
-  "${PYTHON_CMD[@]}" -m venv "$BACKEND_VENV"
-fi
+  if ! "${PYTHON_CMD[@]}" -m pip --version >/dev/null 2>&1; then
+    error "pip for Python 3 is not available. Install pip (usually via '$python_display -m ensurepip --upgrade' or your package manager)."
+    exit 1
+  fi
 
-if [ -x "$BACKEND_VENV/bin/python" ]; then
-  BACKEND_PYTHON="$BACKEND_VENV/bin/python"
-elif [ -x "$BACKEND_VENV/Scripts/python.exe" ]; then
-  BACKEND_PYTHON="$BACKEND_VENV/Scripts/python.exe"
-else
-  error "Unable to locate the Python interpreter inside the virtual environment at $BACKEND_VENV."
-  exit 1
-fi
+  check_command node "Node.js"
+  check_command npm "npm (Node Package Manager)"
 
-info "Installing backend dependencies..."
-"$BACKEND_PYTHON" -m pip install -r "$BACKEND_DIR/requirements.txt"
+  load_env_if_present "$ROOT_DIR/.env"
 
+  if [ ! -x "$BACKEND_VENV/bin/python" ] && [ ! -x "$BACKEND_VENV/Scripts/python.exe" ]; then
+    info "Creating Python virtual environment for backend at $BACKEND_VENV"
+    "${PYTHON_CMD[@]}" -m venv "$BACKEND_VENV"
+  fi
 
-# 4. Prepare frontend dependencies
-if [ ! -d "$FRONTEND_DIR/node_modules" ]; then
-  info "Installing frontend dependencies (this may take a moment)..."
-  (cd "$FRONTEND_DIR" && npm install)
-else
-  info "Frontend dependencies already installed."
-fi
+  if [ -x "$BACKEND_VENV/bin/python" ]; then
+    BACKEND_PYTHON="$BACKEND_VENV/bin/python"
+  elif [ -x "$BACKEND_VENV/Scripts/python.exe" ]; then
+    BACKEND_PYTHON="$BACKEND_VENV/Scripts/python.exe"
+  else
+    error "Unable to locate the Python interpreter inside the virtual environment at $BACKEND_VENV."
+    exit 1
+  fi
 
-# 5. Launch backend server
-start_backend() {
+  info "Installing backend dependencies..."
+  "$BACKEND_PYTHON" -m pip install -r "$BACKEND_DIR/requirements.txt"
+
+  if [ ! -d "$FRONTEND_DIR/node_modules" ]; then
+    info "Installing frontend dependencies (this may take a moment)..."
+    (cd "$FRONTEND_DIR" && npm install)
+  else
+    info "Frontend dependencies already installed."
+  fi
+}
+
+ensure_state_dirs() {
+  mkdir -p "$PID_DIR" "$LOG_DIR"
+}
+
+is_pid_running() {
+  local pid="$1"
+  if [ -z "${pid:-}" ]; then
+    return 1
+  fi
+  if kill -0 "$pid" >/dev/null 2>&1; then
+    return 0
+  fi
+  return 1
+}
+
+stop_pid() {
+  local pid="$1"
+  local name="$2"
+
+  if ! is_pid_running "$pid"; then
+    return
+  fi
+
+  info "Stopping $name (PID $pid)..."
+  if ! kill "$pid" >/dev/null 2>&1; then
+    error "Failed to send termination signal to $name (PID $pid)."
+    return
+  fi
+
+  for _ in {1..50}; do
+    if ! is_pid_running "$pid"; then
+      break
+    fi
+    sleep 0.1
+  done
+
+  if is_pid_running "$pid"; then
+    info "$name did not terminate gracefully; sending SIGKILL."
+    kill -9 "$pid" >/dev/null 2>&1 || true
+  fi
+}
+
+start_backend_foreground() {
   (
     cd "$BACKEND_DIR"
     load_env_if_present "$BACKEND_DIR/.env"
     exec "$BACKEND_PYTHON" -m uvicorn app.main:app --reload
-
   ) &
   local pid=$!
   PIDS+=("$pid")
   info "Backend server started (PID $pid)."
 }
 
-# 6. Launch frontend server
-start_frontend() {
+start_frontend_foreground() {
   (
     cd "$FRONTEND_DIR"
     load_env_if_present "$FRONTEND_DIR/.env"
@@ -165,13 +206,37 @@ start_frontend() {
   info "Frontend server started (PID $pid)."
 }
 
-start_backend
-start_frontend
+cleanup_foreground() {
+  if [ "${CLEANED_UP:-0}" -eq 1 ]; then
+    return
+  fi
+  CLEANED_UP=1
+  echo
+  info "Shutting down services..."
+  for pid in "${PIDS[@]:-}"; do
+    if [ -n "${pid:-}" ] && kill -0 "$pid" >/dev/null 2>&1; then
+      kill "$pid" >/dev/null 2>&1 || true
+    fi
+  done
+  for pid in "${PIDS[@]:-}"; do
+    if [ -n "${pid:-}" ]; then
+      wait "$pid" >/dev/null 2>&1 || true
+    fi
+  done
+  info "All services stopped."
+}
 
-info "Both services are running. Press Ctrl+C to stop."
+run_foreground() {
+  PIDS=()
+  CLEANED_UP=0
+  trap 'cleanup_foreground; exit 0' INT TERM
+  trap cleanup_foreground EXIT
 
-# Keep script running until one of the services exits
-wait_for_services() {
+  start_backend_foreground
+  start_frontend_foreground
+
+  info "Both services are running. Press Ctrl+C to stop."
+
   if help wait 2>/dev/null | grep -q -- "-n"; then
     while true; do
       if ! wait -n; then
@@ -182,28 +247,215 @@ wait_for_services() {
         break
       fi
     done
+  else
+    info "Current shell does not support 'wait -n'; using portable process monitoring."
+    while true; do
+      for pid in "${PIDS[@]}"; do
+        if [ -n "${pid:-}" ] && ! kill -0 "$pid" >/dev/null 2>&1; then
+          status=0
+          if ! wait "$pid" >/dev/null 2>&1; then
+            status=$?
+          fi
+          if [ "$status" -ne 0 ]; then
+            error "One of the services exited unexpectedly (status $status)."
+          fi
+          return
+        fi
+      done
+      sleep 1
+    done
+  fi
+}
+
+pid_file_for() {
+  local name="$1"
+  echo "$PID_DIR/$name.pid"
+}
+
+log_file_for() {
+  local name="$1"
+  echo "$LOG_DIR/$name.log"
+}
+
+ensure_log_file_exists() {
+  local file="$1"
+  if [ ! -f "$file" ]; then
+    : >"$file"
+  fi
+}
+
+start_background_service() {
+  local name="$1"
+  local start_command="$2"
+  local pid_file
+  pid_file="$(pid_file_for "$name")"
+
+  if [ -f "$pid_file" ]; then
+    local existing_pid
+    existing_pid="$(cat "$pid_file")"
+    if is_pid_running "$existing_pid"; then
+      info "$name is already running (PID $existing_pid)."
+      return 0
+    fi
+    info "Removing stale PID file for $name."
+    rm -f "$pid_file"
+  fi
+
+  local log_file
+  log_file="$(log_file_for "$name")"
+  : >"$log_file"
+
+  info "Starting $name in background (logs: $log_file)..."
+  bash -c "$start_command" >>"$log_file" 2>&1 &
+  local pid=$!
+  builtin disown "$pid" 2>/dev/null || true
+  echo "$pid" >"$pid_file"
+  info "$name started with PID $pid."
+}
+
+start_background() {
+  ensure_state_dirs
+
+  local backend_cmd frontend_cmd
+  backend_cmd="$(cat <<EOF
+$(declare -f info)
+$(declare -f load_env_if_present)
+
+cd '$BACKEND_DIR'
+load_env_if_present '$BACKEND_DIR/.env'
+exec '$BACKEND_PYTHON' -m uvicorn app.main:app --reload
+EOF
+)"
+  frontend_cmd="$(cat <<EOF
+$(declare -f info)
+$(declare -f load_env_if_present)
+
+cd '$FRONTEND_DIR'
+load_env_if_present '$FRONTEND_DIR/.env'
+exec npm run dev
+EOF
+)"
+
+  start_background_service "backend" "$backend_cmd"
+  start_background_service "frontend" "$frontend_cmd"
+
+  info "Background services running. Use './launch.sh logs' to follow output or './launch.sh down' to stop."
+}
+
+stop_background_service() {
+  local name="$1"
+  local pid_file
+  pid_file="$(pid_file_for "$name")"
+
+  if [ ! -f "$pid_file" ]; then
+    info "$name is not running."
     return
   fi
 
-  # Fallback for shells without wait -n (e.g. macOS default Bash 3.x in VS Code)
-  info "Current shell does not support 'wait -n'; using portable process monitoring."
-  while true; do
-    for pid in "${PIDS[@]}"; do
-      if [ -n "${pid:-}" ] && ! kill -0 "$pid" >/dev/null 2>&1; then
-        status=0
-        if ! wait "$pid" >/dev/null 2>&1; then
-          status=$?
-        fi
-        if [ "$status" -ne 0 ]; then
-          error "One of the services exited unexpectedly (status $status)."
-        fi
-        return
-      fi
-    done
-    sleep 1
-  done
+  local pid
+  pid="$(cat "$pid_file")"
+
+  if is_pid_running "$pid"; then
+    stop_pid "$pid" "$name"
+  else
+    info "$name was not running but a PID file was present."
+  fi
+
+  rm -f "$pid_file"
 }
 
-wait_for_services
+stop_background() {
+  stop_background_service "frontend"
+  stop_background_service "backend"
+  info "Background services stopped."
+}
+
+status_service() {
+  local name="$1"
+  local pid_file
+  pid_file="$(pid_file_for "$name")"
+  if [ -f "$pid_file" ]; then
+    local pid
+    pid="$(cat "$pid_file")"
+    if is_pid_running "$pid"; then
+      echo "$name: running (PID $pid)"
+      return
+    fi
+  fi
+  echo "$name: stopped"
+}
+
+show_status() {
+  ensure_state_dirs
+  status_service "backend"
+  status_service "frontend"
+  echo "Log files:"
+  echo "  Backend : $(log_file_for backend)"
+  echo "  Frontend: $(log_file_for frontend)"
+}
+
+tail_logs() {
+  ensure_state_dirs
+  local target="${1:-all}"
+  local tail_cmd="tail"
+  if ! command -v tail >/dev/null 2>&1; then
+    error "'tail' command not available."
+    echo "Log files available at $(log_file_for backend) and $(log_file_for frontend)."
+    exit 1
+  fi
+
+  ensure_log_file_exists "$(log_file_for backend)"
+  ensure_log_file_exists "$(log_file_for frontend)"
+
+  case "$target" in
+  backend)
+    info "Streaming backend logs..."
+    $tail_cmd -f "$(log_file_for backend)"
+    ;;
+  frontend)
+    info "Streaming frontend logs..."
+    $tail_cmd -f "$(log_file_for frontend)"
+    ;;
+  all|*)
+    info "Streaming backend and frontend logs..."
+    $tail_cmd -f "$(log_file_for backend)" "$(log_file_for frontend)"
+    ;;
+  esac
+}
+
+case "$COMMAND" in
+dev|run|foreground)
+  ensure_prerequisites
+  run_foreground
+  ;;
+up|start|background)
+  ensure_prerequisites
+  start_background
+  ;;
+down|stop)
+  stop_background
+  ;;
+restart)
+  stop_background
+  ensure_prerequisites
+  start_background
+  ;;
+status)
+  show_status
+  ;;
+logs)
+  shift || true
+  tail_logs "${1:-all}"
+  ;;
+-h|--help|help)
+  usage
+  ;;
+*)
+  error "Unknown command: $COMMAND"
+  echo
+  usage
+  exit 1
+  ;;
+esac
 
 exit 0


### PR DESCRIPTION
## Summary
- add start/stop/status/log subcommands to `launch.sh` so both dev servers can stay running in the background while you keep working
- mirror the background management workflow in `launch.ps1`, persisting PID/log files under `.devserver`
- document the new usage in the README and ignore the generated `.devserver/` state

## Testing
- `./launch.sh status`
- `./launch.sh up` *(fails in this environment: pip cannot reach fastapi via proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68dcbc79d7088333b2113d7b90007336