### PR TITLE
Improve data editor UX across projects and clients

### DIFF
--- a/frontend/app/clients/ClientsTable.tsx
+++ b/frontend/app/clients/ClientsTable.tsx
@@ -189,8 +189,16 @@ export function ClientsTable({ clients }: ClientsTableProps): JSX.Element {
     );
   }, [formState]);
 
+  const modalBadgeVariant = isSubmitting ? "info" : canSubmit ? "success" : "warning";
+  const modalStatusLabel = isSubmitting ? "Submitting…" : canSubmit ? "Ready to submit" : "Fill required fields";
+
   const handleClose = () => {
     setIsModalOpen(false);
+    setFormState(initialFormState());
+    setError(null);
+  };
+
+  const handleModalReset = () => {
     setFormState(initialFormState());
     setError(null);
   };
@@ -423,34 +431,58 @@ export function ClientsTable({ clients }: ClientsTableProps): JSX.Element {
                 Close
               </button>
             </div>
+            <div className="editor-toolbar editor-toolbar--compact modal-toolbar">
+              <div>
+                <h4 className="editor-toolbar-title">Client onboarding</h4>
+                <p className="editor-toolbar-description">
+                  Capture the essentials to spin up a workspace and kickoff project.
+                </p>
+              </div>
+              <div className="editor-toolbar-actions">
+                <span className={`badge ${modalBadgeVariant}`}>{modalStatusLabel}</span>
+                <button
+                  type="button"
+                  className="button ghost"
+                  onClick={handleModalReset}
+                  disabled={isSubmitting}
+                >
+                  Clear form
+                </button>
+              </div>
+            </div>
             <form className="form" onSubmit={handleSubmit}>
               <fieldset className="form-section">
                 <legend>Organization</legend>
                 <div className="form-grid">
                   <label>
-                    <span>Organization name</span>
+                    <span className="form-label">Organization name</span>
+                    <span className="form-helper">Legal or DBA name used on proposals and invoices.</span>
                     <input
                       type="text"
                       value={formState.organization_name}
                       onChange={(event) =>
                         setFormState((prev) => ({ ...prev, organization_name: event.target.value }))
                       }
+                      placeholder="e.g. Sunrise Hospitality Group"
                       required
                     />
                   </label>
                   <label>
-                    <span>Billing email</span>
+                    <span className="form-label">Billing email</span>
+                    <span className="form-helper">Primary finance contact for statements and receipts.</span>
                     <input
                       type="email"
                       value={formState.billing_email}
                       onChange={(event) =>
                         setFormState((prev) => ({ ...prev, billing_email: event.target.value }))
                       }
+                      placeholder="finance@client.com"
                       required
                     />
                   </label>
                   <label>
-                    <span>Industry</span>
+                    <span className="form-label">Industry</span>
+                    <span className="form-helper">Tailors benchmarks and suggested playbooks.</span>
                     <select
                       value={formState.industry}
                       onChange={(event) =>
@@ -465,7 +497,8 @@ export function ClientsTable({ clients }: ClientsTableProps): JSX.Element {
                     </select>
                   </label>
                   <label>
-                    <span>Segment</span>
+                    <span className="form-label">Segment</span>
+                    <span className="form-helper">Helps triage success playbooks and service tiers.</span>
                     <select
                       value={formState.segment}
                       onChange={(event) =>
@@ -480,7 +513,8 @@ export function ClientsTable({ clients }: ClientsTableProps): JSX.Element {
                     </select>
                   </label>
                   <label>
-                    <span>Preferred channel</span>
+                    <span className="form-label">Preferred channel</span>
+                    <span className="form-helper">Where the account team should reach out by default.</span>
                     <select
                       value={formState.preferred_channel}
                       onChange={(event) =>
@@ -498,7 +532,8 @@ export function ClientsTable({ clients }: ClientsTableProps): JSX.Element {
                     </select>
                   </label>
                   <label>
-                    <span>Timezone</span>
+                    <span className="form-label">Timezone</span>
+                    <span className="form-helper">Keep scheduling aligned with the client team.</span>
                     <input
                       type="text"
                       value={formState.timezone}
@@ -515,7 +550,8 @@ export function ClientsTable({ clients }: ClientsTableProps): JSX.Element {
                 <legend>Primary contact</legend>
                 <div className="form-grid">
                   <label>
-                    <span>First name</span>
+                    <span className="form-label">First name</span>
+                    <span className="form-helper">Primary relationship owner on the client side.</span>
                     <input
                       type="text"
                       value={formState.contact.first_name}
@@ -528,7 +564,8 @@ export function ClientsTable({ clients }: ClientsTableProps): JSX.Element {
                     />
                   </label>
                   <label>
-                    <span>Last name</span>
+                    <span className="form-label">Last name</span>
+                    <span className="form-helper">Helps personalize automated communications.</span>
                     <input
                       type="text"
                       value={formState.contact.last_name}
@@ -541,7 +578,8 @@ export function ClientsTable({ clients }: ClientsTableProps): JSX.Element {
                     />
                   </label>
                   <label>
-                    <span>Email</span>
+                    <span className="form-label">Email</span>
+                    <span className="form-helper">We'll send kickoff notes and status digests here.</span>
                     <input
                       type="email"
                       value={formState.contact.email}
@@ -554,7 +592,8 @@ export function ClientsTable({ clients }: ClientsTableProps): JSX.Element {
                     />
                   </label>
                   <label>
-                    <span>Phone</span>
+                    <span className="form-label">Phone</span>
+                    <span className="form-helper">Optional. Add for urgent SMS or call updates.</span>
                     <input
                       type="tel"
                       value={formState.contact.phone}
@@ -568,7 +607,8 @@ export function ClientsTable({ clients }: ClientsTableProps): JSX.Element {
                     />
                   </label>
                   <label>
-                    <span>Title</span>
+                    <span className="form-label">Title</span>
+                    <span className="form-helper">Optional role for context in reports.</span>
                     <input
                       type="text"
                       value={formState.contact.title}
@@ -588,7 +628,8 @@ export function ClientsTable({ clients }: ClientsTableProps): JSX.Element {
                 <legend>Initial project</legend>
                 <div className="form-grid">
                   <label>
-                    <span>Project name</span>
+                    <span className="form-label">Project name</span>
+                    <span className="form-helper">How the engagement will appear across dashboards.</span>
                     <input
                       type="text"
                       value={formState.project.name}
@@ -598,11 +639,13 @@ export function ClientsTable({ clients }: ClientsTableProps): JSX.Element {
                           project: { ...prev.project, name: event.target.value }
                         }))
                       }
+                      placeholder="e.g. Midtown hotel launch"
                       required
                     />
                   </label>
                   <label>
-                    <span>Project type</span>
+                    <span className="form-label">Project type</span>
+                    <span className="form-helper">Select the template that matches this kickoff.</span>
                     <select
                       value={formState.project.project_type}
                       onChange={(event) =>
@@ -620,7 +663,8 @@ export function ClientsTable({ clients }: ClientsTableProps): JSX.Element {
                     </select>
                   </label>
                   <label>
-                    <span>Start date</span>
+                    <span className="form-label">Start date</span>
+                    <span className="form-helper">We’ll schedule milestones starting from this day.</span>
                     <input
                       type="date"
                       value={formState.project.start_date}
@@ -634,7 +678,8 @@ export function ClientsTable({ clients }: ClientsTableProps): JSX.Element {
                     />
                   </label>
                   <label>
-                    <span>Project manager ID</span>
+                    <span className="form-label">Project manager ID</span>
+                    <span className="form-helper">Assign the delivery lead responsible for execution.</span>
                     <input
                       type="text"
                       value={formState.project.manager_id}
@@ -644,11 +689,13 @@ export function ClientsTable({ clients }: ClientsTableProps): JSX.Element {
                           project: { ...prev.project, manager_id: event.target.value }
                         }))
                       }
+                      placeholder="e.g. pm-104"
                       required
                     />
                   </label>
                   <label>
-                    <span>Budget (USD)</span>
+                    <span className="form-label">Budget</span>
+                    <span className="form-helper">Accepted budget for the initial scope.</span>
                     <input
                       type="number"
                       min="0"
@@ -660,11 +707,13 @@ export function ClientsTable({ clients }: ClientsTableProps): JSX.Element {
                           project: { ...prev.project, budget: event.target.value }
                         }))
                       }
+                      placeholder="e.g. 50000"
                       required
                     />
                   </label>
                   <label>
-                    <span>Currency</span>
+                    <span className="form-label">Currency</span>
+                    <span className="form-helper">Optional. Defaults to USD.</span>
                     <input
                       type="text"
                       value={formState.project.currency}
@@ -674,10 +723,12 @@ export function ClientsTable({ clients }: ClientsTableProps): JSX.Element {
                           project: { ...prev.project, currency: event.target.value }
                         }))
                       }
+                      placeholder="USD"
                     />
                   </label>
-                  <label>
-                    <span>Starts after (optional dependency)</span>
+                  <label className="full-width">
+                    <span className="form-label">Starts after (optional dependency)</span>
+                    <span className="form-helper">Reference another project that must finish before this one.</span>
                     <input
                       type="text"
                       value={formState.project.start_after}

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -89,6 +89,43 @@ main {
   border-bottom: 1px solid rgba(139, 57, 33, 0.1);
 }
 
+.table thead th {
+  background: rgba(139, 57, 33, 0.08);
+  font-size: 0.8rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: rgba(63, 34, 22, 0.75);
+}
+
+.table tbody tr:nth-child(even) {
+  background: rgba(255, 255, 255, 0.5);
+}
+
+.table tbody tr:hover {
+  background: rgba(255, 248, 241, 0.85);
+}
+
+.table-editor td,
+.table-editor th {
+  vertical-align: top;
+}
+
+.table-editor input,
+.table-editor select {
+  width: 100%;
+  padding: 0.5rem 0.65rem;
+  border-radius: 0.6rem;
+  border: 1px solid rgba(139, 57, 33, 0.25);
+  background: rgba(255, 255, 255, 0.92);
+}
+
+.table-editor input:focus,
+.table-editor select:focus {
+  outline: none;
+  border-color: rgba(139, 57, 33, 0.55);
+  box-shadow: 0 0 0 3px rgba(192, 105, 77, 0.2);
+}
+
 .badge {
   display: inline-flex;
   align-items: center;
@@ -266,11 +303,49 @@ main {
   }
 }
 
+@media (min-width: 1200px) {
+  .form-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
 .form-grid label {
   display: flex;
   flex-direction: column;
   gap: 0.35rem;
   font-size: 0.95rem;
+}
+
+.form-label {
+  font-weight: 600;
+  color: var(--color-ink);
+}
+
+.form-helper {
+  font-size: 0.8rem;
+  color: var(--color-muted);
+  line-height: 1.35;
+}
+
+.form-grid .full-width {
+  grid-column: 1 / -1;
+}
+
+.form-checkbox {
+  flex-direction: row;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.form-checkbox-text {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.form-checkbox input[type="checkbox"] {
+  width: auto;
+  align-self: center;
 }
 
 .form-grid input,
@@ -289,6 +364,89 @@ main {
   outline: none;
   border-color: rgba(139, 57, 33, 0.55);
   box-shadow: 0 0 0 3px rgba(192, 105, 77, 0.25);
+}
+
+.editor-toolbar {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  margin: 1.5rem 0;
+  padding: 1rem 1.25rem;
+  border: 1px solid rgba(139, 57, 33, 0.18);
+  border-radius: 1rem;
+  background: rgba(255, 255, 255, 0.65);
+}
+
+@media (min-width: 768px) {
+  .editor-toolbar {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
+}
+
+.editor-toolbar--compact {
+  margin-top: 1rem;
+  margin-bottom: 1rem;
+}
+
+.modal-toolbar {
+  margin-top: 0;
+  margin-bottom: 1.25rem;
+}
+
+.editor-toolbar-title {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 600;
+}
+
+.editor-toolbar-description {
+  margin: 0.25rem 0 0 0;
+  font-size: 0.9rem;
+  color: var(--color-muted);
+  max-width: 520px;
+}
+
+.editor-toolbar-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.editor-summary {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.editor-summary-item {
+  padding: 1rem 1.25rem;
+  border: 1px solid rgba(139, 57, 33, 0.18);
+  border-radius: 0.9rem;
+  background: rgba(255, 255, 255, 0.7);
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.editor-summary-item strong {
+  font-size: 1.05rem;
+  color: var(--color-primary);
+}
+
+.editor-summary-label {
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: rgba(63, 34, 22, 0.7);
+}
+
+.editor-summary-helper {
+  font-size: 0.8rem;
+  color: var(--color-muted);
 }
 
 .form-actions {


### PR DESCRIPTION
## Summary
- add save state tracking, reset controls, and summary metrics to the project portfolio editor
- refresh client onboarding modal with contextual helper text, readiness badges, and quick reset actions
- extend shared styling for forms and editable tables to deliver a clearer, more tactile editing experience

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68de432bdea88333b3063b0fc5cf27d5