### PR TITLE
Add subscription-aware client revenue tracking

### DIFF
--- a/backend/app/schemas/financials.py
+++ b/backend/app/schemas/financials.py
@@ -11,6 +11,8 @@ class Currency(str, Enum):
     USD = "USD"
     EUR = "EUR"
     GBP = "GBP"
+    PHP = "PHP"
+    SGD = "SGD"
 
 
 class InvoiceStatus(str, Enum):

--- a/backend/tests/test_clients.py
+++ b/backend/tests/test_clients.py
@@ -43,6 +43,22 @@ def _cleanup(client_id: str, project_ids: Iterable[str]) -> None:
         store.projects.pop(project_id, None)
 
 
+def _revenue_profile(
+    classification: str = "multi_payment",
+    amount: float = 48000.0,
+    currency: str = "USD",
+) -> dict:
+    profile = {
+        "classification": classification,
+        "amount": amount,
+        "currency": currency,
+        "autopay": classification.endswith("subscription"),
+    }
+    if classification == "multi_payment":
+        profile.update({"payment_count": 4, "remaining_balance": amount / 2})
+    return profile
+
+
 def _seeded_client_with_data() -> Client:
     for client in store.clients.values():
         if client.organization_name == "Sunset Boutique Hotel":
@@ -77,6 +93,7 @@ def test_create_client_with_single_project_template() -> None:
                 "currency": "USD",
             }
         ],
+        "revenue_profile": _revenue_profile(amount=52000.0),
     }
 
     response = client.post("/api/v1/clients", json=payload)
@@ -140,6 +157,7 @@ def test_branding_then_website_sequence() -> None:
                 "currency": "USD",
             },
         ],
+        "revenue_profile": _revenue_profile(amount=77000.0),
     }
 
     response = client.post("/api/v1/clients", json=payload)
@@ -207,6 +225,7 @@ def test_create_and_use_custom_project_template() -> None:
                 "currency": "USD",
             }
         ],
+        "revenue_profile": _revenue_profile(amount=36000.0),
     }
 
     response = client.post("/api/v1/clients", json=client_payload)

--- a/frontend/app/clients/CRMOverview.tsx
+++ b/frontend/app/clients/CRMOverview.tsx
@@ -6,6 +6,12 @@ const currencyFormatter = new Intl.NumberFormat("en-PH", {
   maximumFractionDigits: 0
 });
 
+const usdFormatter = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+  maximumFractionDigits: 0
+});
+
 const numberFormatter = new Intl.NumberFormat("en-US", { maximumFractionDigits: 0 });
 const percentFormatter = new Intl.NumberFormat("en-US", { maximumFractionDigits: 1 });
 
@@ -71,6 +77,17 @@ function formatChannel(channel: string): string {
     default:
       return channel;
   }
+}
+
+function formatUsd(amount: number): string {
+  return usdFormatter.format(amount);
+}
+
+function formatMonthlyValue(amount: number): string {
+  if (!amount) {
+    return "—";
+  }
+  return `${formatUsd(amount)} / mo`;
 }
 
 interface CRMOverviewProps {
@@ -143,6 +160,49 @@ export function CRMOverview({ overview }: CRMOverviewProps): JSX.Element {
                     </td>
                   </tr>
                 ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        <section className="crm-section" aria-labelledby="crm-revenue-title">
+          <div className="crm-section-header">
+            <div>
+              <h4 id="crm-revenue-title">Revenue mix</h4>
+              <p className="crm-section-subtitle">Breakdown of billing models and renewal exposure.</p>
+            </div>
+          </div>
+          <div className="table-scroll">
+            <table className="table crm-pipeline-table">
+              <thead>
+                <tr>
+                  <th scope="col">Model</th>
+                  <th scope="col">Accounts</th>
+                  <th scope="col">Contract value</th>
+                  <th scope="col">Monthly value</th>
+                  <th scope="col">Upcoming renewals</th>
+                  <th scope="col">Outstanding balance</th>
+                </tr>
+              </thead>
+              <tbody>
+                {overview.revenue_mix.length === 0 ? (
+                  <tr>
+                    <td colSpan={6} className="text-muted">
+                      No billing data yet.
+                    </td>
+                  </tr>
+                ) : (
+                  overview.revenue_mix.map((slice) => (
+                    <tr key={slice.classification}>
+                      <th scope="row">{slice.label}</th>
+                      <td>{numberFormatter.format(slice.client_count)}</td>
+                      <td>{formatUsd(slice.total_value)}</td>
+                      <td>{formatMonthlyValue(slice.monthly_value)}</td>
+                      <td>{slice.upcoming_renewals > 0 ? numberFormatter.format(slice.upcoming_renewals) : "—"}</td>
+                      <td>{slice.open_balance ? formatUsd(slice.open_balance) : "—"}</td>
+                    </tr>
+                  ))
+                )}
               </tbody>
             </table>
           </div>

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -902,6 +902,22 @@ main {
   color: #6f4d3d;
 }
 
+.crm-revenue-cell {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.crm-revenue-amount {
+  font-weight: 600;
+  color: #2f2f2f;
+}
+
+.crm-revenue-meta {
+  color: #6f4d3d;
+  font-size: 0.8rem;
+}
+
 .crm-last-touch {
   font-weight: 600;
   color: #6f4d3d;

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -11,6 +11,11 @@ async function getDashboard(): Promise<DashboardSnapshot> {
 
 export default async function DashboardPage(): Promise<JSX.Element> {
   const data = await getDashboard();
+  const recurringAccounts =
+    (data.clients.by_revenue_profile?.monthly_subscription ?? 0) +
+    (data.clients.by_revenue_profile?.annual_subscription ?? 0);
+  const installmentAccounts = data.clients.by_revenue_profile?.multi_payment ?? 0;
+  const oneTimeAccounts = data.clients.by_revenue_profile?.one_time ?? 0;
 
   return (
     <div>
@@ -39,6 +44,12 @@ export default async function DashboardPage(): Promise<JSX.Element> {
           value={String(data.monitoring.incidents_today)}
           helper="Last 24 hours"
           tone={data.monitoring.incidents_today > 0 ? "danger" : "success"}
+        />
+        <MetricCard
+          title="Recurring accounts"
+          value={`${recurringAccounts}`}
+          helper={`${installmentAccounts} installment • ${oneTimeAccounts} one-time`}
+          tone="success"
         />
         <MetricCard
           title="Portal adoption"

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -75,6 +75,7 @@ export interface DashboardSnapshot {
     total_clients: number;
     by_segment: Record<string, number>;
     active_portal_users: number;
+    by_revenue_profile: Record<string, number>;
   };
   financials: {
     mrr: number;
@@ -374,6 +375,23 @@ export interface ClientDocument extends TimestampedEntity {
   signed: boolean;
 }
 
+export type RevenueClassification =
+  | "monthly_subscription"
+  | "annual_subscription"
+  | "one_time"
+  | "multi_payment";
+
+export interface ClientRevenueProfile {
+  classification: RevenueClassification;
+  amount: number;
+  currency: string;
+  autopay: boolean;
+  next_payment_due?: string | null;
+  last_payment_at?: string | null;
+  payment_count?: number | null;
+  remaining_balance?: number | null;
+}
+
 export interface Client extends TimestampedEntity {
   id: string;
   organization_name: string;
@@ -385,6 +403,7 @@ export interface Client extends TimestampedEntity {
   contacts?: Contact[];
   interactions?: Interaction[];
   documents?: ClientDocument[];
+  revenue_profile: ClientRevenueProfile;
 }
 
 export interface ClientProjectDigest {
@@ -487,12 +506,23 @@ export interface CRMContactGap {
   recommended_role: string;
 }
 
+export interface RevenueMixSlice {
+  classification: RevenueClassification;
+  label: string;
+  client_count: number;
+  total_value: number;
+  monthly_value: number;
+  open_balance: number;
+  upcoming_renewals: number;
+}
+
 export interface ClientCRMOverview {
   generated_at: string;
   metrics: CRMMetric[];
   pipeline: CRMPipelineStage[];
   interaction_gaps: CRMInteractionGap[];
   contact_gaps: CRMContactGap[];
+  revenue_mix: RevenueMixSlice[];
 }
 
 export interface ProjectSetup {
@@ -514,6 +544,7 @@ export interface ClientCreateRequest {
   timezone: string;
   contacts: ContactInput[];
   projects: ProjectSetup[];
+  revenue_profile: ClientRevenueProfile;
 }
 
 export interface ClientWithProjects {


### PR DESCRIPTION
## Summary
- extend client schemas with revenue profiles and classification enums to capture subscription, installment, and one-time billing data
- enrich seed data, summaries, and CRM overview with revenue mix analytics surfaced to the UI
- update frontend tables, forms, and dashboards to display and filter clients by billing model alongside new styling tweaks

## Testing
- pytest backend
- npm run lint --prefix frontend

------
https://chatgpt.com/codex/tasks/task_e_68e48bcdb47883338e9303ffddeeaf57