### PR TITLE
Use timezone-aware UTC timestamps

### DIFF
--- a/backend/app/core/datetime_utils.py
+++ b/backend/app/core/datetime_utils.py
@@ -1,0 +1,12 @@
+"""Datetime helpers for consistently using timezone-aware UTC values."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+
+def utc_now() -> datetime:
+    """Return the current UTC time as a timezone-aware datetime."""
+
+    return datetime.now(timezone.utc)
+

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -5,6 +5,7 @@ import jwt
 from passlib.context import CryptContext
 
 from .config import get_settings
+from .datetime_utils import utc_now
 
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 
@@ -13,7 +14,7 @@ def create_access_token(subject: str, expires_delta: timedelta | None = None) ->
     settings = get_settings()
     if expires_delta is None:
         expires_delta = timedelta(minutes=settings.access_token_expire_minutes)
-    expire = datetime.utcnow() + expires_delta
+    expire = utc_now() + expires_delta
     payload: Dict[str, Any] = {"exp": expire, "sub": str(subject)}
     encoded_jwt = jwt.encode(payload, settings.secret_key, algorithm=settings.security_algorithm)
     return encoded_jwt

--- a/backend/app/schemas/clients.py
+++ b/backend/app/schemas/clients.py
@@ -9,6 +9,7 @@ from .common import IdentifiedModel
 from .financials import Currency, InvoiceStatus
 from .projects import Milestone, Project, ProjectStatus, Task
 from .support import TicketStatus
+from ..core.datetime_utils import utc_now
 
 
 class Industry(str, Enum):
@@ -314,7 +315,7 @@ class RevenueMixSlice(BaseModel):
 
 
 class ClientCRMOverview(BaseModel):
-    generated_at: datetime = Field(default_factory=datetime.utcnow)
+    generated_at: datetime = Field(default_factory=utc_now)
     metrics: List[CRMMetric] = Field(default_factory=list)
     pipeline: List[CRMPipelineStage] = Field(default_factory=list)
     interaction_gaps: List[CRMInteractionGap] = Field(default_factory=list)

--- a/backend/app/schemas/common.py
+++ b/backend/app/schemas/common.py
@@ -3,14 +3,16 @@ from typing import Optional
 from pydantic import BaseModel, Field
 import uuid
 
+from ..core.datetime_utils import utc_now
+
 
 def generate_uuid() -> str:
     return str(uuid.uuid4())
 
 
 class TimestampedModel(BaseModel):
-    created_at: datetime = Field(default_factory=datetime.utcnow)
-    updated_at: datetime = Field(default_factory=datetime.utcnow)
+    created_at: datetime = Field(default_factory=utc_now)
+    updated_at: datetime = Field(default_factory=utc_now)
     deleted_at: Optional[datetime] = None
 
 

--- a/backend/app/services/automation.py
+++ b/backend/app/services/automation.py
@@ -20,6 +20,7 @@ from ..schemas.marketing import Campaign, ContentItem, ContentStatus
 from ..schemas.monitoring import Check, Site
 from ..schemas.projects import ProjectHealth, ProjectStatus
 from ..schemas.support import TicketStatus
+from ..core.datetime_utils import utc_now
 from .data import InMemoryStore
 
 
@@ -51,7 +52,7 @@ class AutomationEngine:
 
     @property
     def now(self) -> datetime:
-        return self._now or datetime.utcnow()
+        return self._now or utc_now()
 
     def generate_digest(self) -> AutomationDigest:
         """Build a digest capturing automation tasks across domains."""

--- a/backend/app/services/project_templates.py
+++ b/backend/app/services/project_templates.py
@@ -5,6 +5,7 @@ from datetime import datetime, timedelta
 from typing import Dict, Iterable, List, Optional
 
 from ..schemas.projects import Milestone, Task, TaskPriority, TaskStatus, TaskType
+from ..core.datetime_utils import utc_now
 
 
 @dataclass(frozen=True)
@@ -332,5 +333,5 @@ def list_templates() -> Dict[str, ProjectTemplate]:
 
 
 def project_code(prefix: str, sequence: int, *, year: int | None = None) -> str:
-    year = year or datetime.utcnow().year
+    year = year or utc_now().year
     return f"{prefix}-{year}-{sequence:02d}"

--- a/backend/tests/test_financials.py
+++ b/backend/tests/test_financials.py
@@ -1,4 +1,4 @@
-from datetime import date, datetime
+from datetime import date, datetime, timezone
 import sys
 import typing
 
@@ -100,7 +100,7 @@ def test_tax_profile_includes_business_context_and_calendar() -> None:
 
 def test_pricing_suggestions_flag_low_margin_projects() -> None:
     project = next(iter(store.projects.values()))
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     invoice = Invoice(
         client_id=project.client_id,
         project_id=project.id,

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 import inspect
 from pathlib import Path
 import sys
@@ -47,7 +47,7 @@ def test_dashboard_snapshot() -> None:
 
 
 def test_financial_summary_outstanding_reflects_partial_payments() -> None:
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     invoice = Invoice(
         client_id="test-client",
         project_id=None,

--- a/backend/tests/test_projects.py
+++ b/backend/tests/test_projects.py
@@ -1,6 +1,6 @@
 import inspect
 import sys
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import ForwardRef
 
@@ -47,7 +47,7 @@ def test_project_tracker_surfaces_automation_and_notifications() -> None:
     original_discovery = discovery_task.copy(deep=True)
     original_ux = ux_task.copy(deep=True)
 
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
 
     reset_payload = {
         "tasks": [


### PR DESCRIPTION
## Summary
- add a reusable helper for timezone-aware UTC timestamps
- replace naive `datetime.utcnow()` usage across services, schemas, and tests to avoid deprecation warnings

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e49a76540c8333b2c35d21e95aeb78