### PR TITLE
Configure custom port for application

### DIFF
--- a/.env.docker.example
+++ b/.env.docker.example
@@ -1,14 +1,18 @@
 # Docker Environment Configuration
 # Copy this file to .env and update the values for your environment
 
+# Port Configuration
+FRONTEND_PORT=3000
+BACKEND_PORT=8000
+
 # Backend Configuration
 SECRET_KEY=change-me-to-a-secure-random-string-in-production
-CORS_ORIGINS=http://localhost:3000
+CORS_ORIGINS=http://localhost:${FRONTEND_PORT:-3000}
 
 # Frontend Configuration
-NEXT_PUBLIC_API_BASE=http://localhost:8000/api/v1
+NEXT_PUBLIC_API_BASE=http://localhost:${BACKEND_PORT:-8000}/api/v1
 # Internal API URL for server-side requests within Docker network
-API_BASE_INTERNAL=http://backend:8000/api/v1
+API_BASE_INTERNAL=http://backend:${BACKEND_PORT:-8000}/api/v1
 
 # Optional: Database Configuration (for future use)
 # DATABASE_URL=postgresql://user:password@postgres:5432/disenyorita

--- a/README.md
+++ b/README.md
@@ -304,11 +304,73 @@ For a containerized deployment using Docker Desktop, the repository provides Doc
 - Production-ready configuration with standalone Next.js output
 - Network isolation with dedicated Docker bridge network
 
+**Custom Port Configuration:**
+
+If you need to use different ports (e.g., because you're running multiple servers), you can configure custom ports using environment variables:
+
+1. **Create a .env file** from the template:
+   ```bash
+   cp .env.docker.example .env
+   ```
+
+2. **Set your desired ports** in `.env`:
+   ```bash
+   # Port Configuration
+   FRONTEND_PORT=4000    # Change from default 3000
+   BACKEND_PORT=9000     # Change from default 8000
+
+   # Backend Configuration
+   SECRET_KEY=your-secret-key
+   CORS_ORIGINS=http://localhost:4000
+
+   # Frontend Configuration
+   NEXT_PUBLIC_API_BASE=http://localhost:9000/api/v1
+   API_BASE_INTERNAL=http://backend:9000/api/v1
+   ```
+
+3. **Launch with custom ports**:
+   ```bash
+   # Using docker compose
+   docker compose up -d
+
+   # Or using the PowerShell script
+   .\docker-launch.ps1 up
+   ```
+
+4. **Access your application**:
+   - Frontend: `http://localhost:4000` (or your FRONTEND_PORT)
+   - Backend API: `http://localhost:9000` (or your BACKEND_PORT)
+   - API Documentation: `http://localhost:9000/docs`
+
+**For local development** (without Docker), you can also set ports:
+
+Backend:
+```bash
+cd backend
+export BACKEND_PORT=9000  # Linux/macOS
+# or
+set BACKEND_PORT=9000     # Windows CMD
+uvicorn app.main:app --host 0.0.0.0 --port $BACKEND_PORT
+```
+
+Frontend:
+```bash
+cd frontend
+# Add to .env.local
+FRONTEND_PORT=4000
+NEXT_PUBLIC_API_BASE=http://localhost:9000/api/v1
+
+# Run with custom port
+PORT=4000 npm run dev
+```
+
 **Troubleshooting:**
 - If containers fail to start, check Docker Desktop is running
 - View detailed logs with `.\docker-launch.ps1 logs` or `docker compose logs`
 - Rebuild containers after dependency changes with `.\docker-launch.ps1 rebuild`
-- Ensure ports 3000 and 8000 are not already in use
+- Ensure your chosen ports are not already in use
+- When changing ports, update both `FRONTEND_PORT`/`BACKEND_PORT` and the corresponding API URLs
+- Make sure CORS_ORIGINS includes your frontend port
 
 ## Testing
 ⚠️ Tests not run (planning document only).

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,2 +1,5 @@
+# Backend Port (default: 8000)
+BACKEND_PORT=8000
+
 SECRET_KEY=change-me
 CORS_ORIGINS=http://localhost:3000

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -25,12 +25,15 @@ RUN pip install --no-cache-dir -r requirements.txt
 # Copy application code
 COPY . .
 
-# Expose port
-EXPOSE 8000
+# Set default port
+ENV BACKEND_PORT=8000
 
-# Health check
+# Expose port (will be overridden by environment variable)
+EXPOSE ${BACKEND_PORT}
+
+# Health check (uses environment variable for port)
 HEALTHCHECK --interval=30s --timeout=3s --start-period=40s --retries=3 \
-    CMD python -c "import requests; requests.get('http://localhost:8000/api/v1/health', timeout=2)" || exit 1
+    CMD python -c "import os, requests; port = os.getenv('BACKEND_PORT', '8000'); requests.get(f'http://localhost:{port}/api/v1/health', timeout=2)" || exit 1
 
-# Run the application
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]
+# Run the application with configurable port
+CMD sh -c "uvicorn app.main:app --host 0.0.0.0 --port ${BACKEND_PORT}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,10 +7,11 @@ services:
       dockerfile: Dockerfile
     container_name: disenyorita-backend
     ports:
-      - "8000:8000"
+      - "${BACKEND_PORT:-8000}:${BACKEND_PORT:-8000}"
     environment:
+      - BACKEND_PORT=${BACKEND_PORT:-8000}
       - SECRET_KEY=${SECRET_KEY:-change-me-in-production}
-      - CORS_ORIGINS=http://localhost:3000,http://frontend:3000
+      - CORS_ORIGINS=${CORS_ORIGINS:-http://localhost:${FRONTEND_PORT:-3000},http://frontend:${FRONTEND_PORT:-3000}}
     volumes:
       # Mount for development - comment out for production
       - ./backend:/app
@@ -19,7 +20,7 @@ services:
       - disenyorita-network
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "python", "-c", "import requests; requests.get('http://localhost:8000/api/v1/health', timeout=2)"]
+      test: ["CMD", "sh", "-c", "python -c \"import os, requests; port = os.getenv('BACKEND_PORT', '8000'); requests.get(f'http://localhost:{port}/api/v1/health', timeout=2)\""]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -30,13 +31,14 @@ services:
       context: ./frontend
       dockerfile: Dockerfile
       args:
-        - NEXT_PUBLIC_API_BASE=http://localhost:8000/api/v1
+        - NEXT_PUBLIC_API_BASE=${NEXT_PUBLIC_API_BASE:-http://localhost:${BACKEND_PORT:-8000}/api/v1}
     container_name: disenyorita-frontend
     ports:
-      - "3000:3000"
+      - "${FRONTEND_PORT:-3000}:${FRONTEND_PORT:-3000}"
     environment:
-      - NEXT_PUBLIC_API_BASE=http://localhost:8000/api/v1
-      - API_BASE_INTERNAL=http://backend:8000/api/v1
+      - FRONTEND_PORT=${FRONTEND_PORT:-3000}
+      - NEXT_PUBLIC_API_BASE=${NEXT_PUBLIC_API_BASE:-http://localhost:${BACKEND_PORT:-8000}/api/v1}
+      - API_BASE_INTERNAL=${API_BASE_INTERNAL:-http://backend:${BACKEND_PORT:-8000}/api/v1}
     depends_on:
       backend:
         condition: service_healthy
@@ -44,7 +46,7 @@ services:
       - disenyorita-network
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "node", "-e", "require('http').get('http://localhost:3000/api/health', (r) => {process.exit(r.statusCode === 200 ? 0 : 1)})"]
+      test: ["CMD", "sh", "-c", "node -e \"require('http').get('http://localhost:${FRONTEND_PORT}/api/health', (r) => {process.exit(r.statusCode === 200 ? 0 : 1)})\""]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,1 +1,5 @@
+# Frontend Port (default: 3000)
+FRONTEND_PORT=3000
+
+# Backend API URL (client-side)
 NEXT_PUBLIC_API_BASE=http://localhost:8000/api/v1

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -43,13 +43,15 @@ COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
 
 USER nextjs
 
-EXPOSE 3000
-
-ENV PORT=3000
+# Set default frontend port
+ENV FRONTEND_PORT=3000
+ENV PORT=${FRONTEND_PORT}
 ENV HOSTNAME="0.0.0.0"
 
-# Health check
+EXPOSE ${FRONTEND_PORT}
+
+# Health check (uses environment variable for port)
 HEALTHCHECK --interval=30s --timeout=3s --start-period=40s --retries=3 \
-    CMD node -e "require('http').get('http://localhost:3000/api/health', (r) => {process.exit(r.statusCode === 200 ? 0 : 1)})" || exit 1
+    CMD sh -c "node -e \"require('http').get('http://localhost:${FRONTEND_PORT}/api/health', (r) => {process.exit(r.statusCode === 200 ? 0 : 1)})\"" || exit 1
 
 CMD ["node", "server.js"]


### PR DESCRIPTION
- Add FRONTEND_PORT and BACKEND_PORT environment variables to all configuration files
- Update backend Dockerfile to use BACKEND_PORT (default: 8000)
- Update frontend Dockerfile to use FRONTEND_PORT (default: 3000)
- Modify docker-compose.yml to support custom ports via environment variables
- Update health checks to use configurable ports
- Add comprehensive documentation in README.md for custom port configuration
- Support both Docker and local development port customization
- Fix CORS_ORIGINS to dynamically use frontend port

This allows users to run multiple servers on different ports without conflicts.