### PR TITLE
Fix Docker backend container health check failure

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,5 +1,5 @@
 # Multi-stage build for Python FastAPI backend
-FROM python:3.11-slim as base
+FROM python:3.11-slim AS base
 
 # Set environment variables
 ENV PYTHONUNBUFFERED=1 \
@@ -33,7 +33,7 @@ EXPOSE ${BACKEND_PORT}
 
 # Health check (uses environment variable for port)
 HEALTHCHECK --interval=30s --timeout=3s --start-period=40s --retries=3 \
-    CMD python -c "import os, requests; port = os.getenv('BACKEND_PORT', '8000'); requests.get(f'http://localhost:{port}/api/v1/health', timeout=2)" || exit 1
+    CMD python -c "import os, requests; port = os.getenv('BACKEND_PORT', '8000'); requests.get(f'http://localhost:{port}/health', timeout=2)" || exit 1
 
 # Run the application with configurable port
 CMD sh -c "uvicorn app.main:app --host 0.0.0.0 --port ${BACKEND_PORT}"

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -6,5 +6,6 @@ passlib[bcrypt]==1.7.4
 bcrypt==4.0.1
 PyJWT==2.8.0
 httpx==0.27.0
+requests==2.31.0
 pytest==8.2.0
 pytest-asyncio==0.23.6

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   backend:
     build:
@@ -20,7 +18,7 @@ services:
       - disenyorita-network
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "sh", "-c", "python -c \"import requests; requests.get('http://localhost:8000/api/v1/health', timeout=2)\""]
+      test: ["CMD", "sh", "-c", "python -c \"import requests; requests.get('http://localhost:8000/health', timeout=2)\""]
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
- Fix healthcheck endpoint path from /api/v1/health to /health
- Add requests library to requirements.txt for healthcheck
- Remove obsolete version field from docker-compose.yml
- Fix Dockerfile casing (as -> AS) in FROM statement

These changes resolve the backend container health check failures that were preventing the containers from starting properly.